### PR TITLE
Tabs Component: accept activeTab as a prop

### DIFF
--- a/client/components/tabs/index.jsx
+++ b/client/components/tabs/index.jsx
@@ -20,13 +20,14 @@ let Tabs = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			activeTab: 0,
 			layout: 'horizontal'
 		};
 	},
 
 	getInitialState: function() {
 		return {
-			activeTab: 0
+			activeTab: this.props.activeTab
 		};
 	},
 


### PR DESCRIPTION
Allows you to pass activeTab as a prop.  Still defaults to `0` index.  Will be helpful with routing.  

```
<Tabs activeTab={ 2  }>
...
</Tabs>
```
