### PR TITLE
Remove wpcom-private. Add wpcom@4.9.12

### DIFF
--- a/client/lib/wpcom-undocumented/index.js
+++ b/client/lib/wpcom-undocumented/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var WPCOM = require( 'wpcom-private' ),
+var WPCOM = require( 'wpcom' ),
 	inherits = require( 'inherits' ),
 	assign = require( 'lodash/object/assign' ),
 	debug = require( 'debug' )( 'calypso:wpcom-undocumented' );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "payment": "0.0.9",
     "react": "^0.13.3",
     "store": "^1.3.17",
-    "wpcom-private": "https://cldup.com/uCVC3inECmP/GHgpcP.tgz#3.6.0",
+    "wpcom": "4.9.12",
     "wpcom-proxy-request": "^1.0.4",
     "wpcom-xhr-request": "^0.3.2"
   },


### PR DESCRIPTION
`wpcom-private` is obsolete. We should change it by wpcom.js.
As far I can see we are using just only one method from `wpcom-undocumented` in store-transitions lib.
### Testing

Test stuff we are making requests to WordPress REST-API.
