### PR TITLE
Chart: Remove non-existent i18n function

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -127,10 +127,8 @@ module.exports = React.createClass( {
 			emptyChart = (
 				<div className="dops-chart__empty">
 					<span className="dops-chart__empty_notice">
-						{ i18n.translate( 'No activity this period', {
-							context: 'Message on empty bar chart in Stats',
-							comment: 'Should be limited to 32 characters to prevent wrapping'
-						} ) }
+						{ /* Translate this. */ }
+						No activity this period
 					</span>
 				</div>
 			);


### PR DESCRIPTION
The app was failing.  

I'd like to propose that in the future we can pass this string via a prop, so that it can be translated by the app.  I can make this happen later, but for now we need the app to work.  