### PR TITLE
Foldable Card: make space consistent when p tags are at the beginning or at the end

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -155,6 +155,14 @@ button.dops-foldable-card__action {
 		.dops-foldable-card.is-compact & {
 			padding: 8px;
 		}
+
+		p:first-child {
+			margin-top: 0;
+		}
+
+		p:last-child {
+			margin-bottom: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
This aims to have consistent spacing at the beginning or at the end of a card. Since the card already applies a padding, when a `p` tag is at the bottom of a card it introduces additional spacing that makes things look uneven.