### PR TITLE
Analytics: whitelist the `jetpack_` prefix for tracks events.

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -107,9 +107,8 @@ var analytics = {
 			eventProperties = eventProperties || {};
 
 			debug( 'Record event "%s" called with props %s', eventName, JSON.stringify( eventProperties ) );
-
-			if ( eventName.indexOf( 'akismet_' ) !== 0 ) {
-				debug( '- Event name must be prefixed by "akismet_"' );
+			if ( eventName.indexOf( 'akismet_' ) !== 0 && eventName.indexOf( 'jetpack_' ) !== 0 ) {
+				debug( '- Event name must be prefixed by "akismet_" or "jetpack_"' );
 				return;
 			}
 


### PR DESCRIPTION
So that we can send events prefixed with `jetpack_`