### PR TITLE
Foldable Card: New prop clickableHeaderText 

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -28,7 +28,9 @@ var FoldableCard = React.createClass( {
 		onClick: React.PropTypes.func,
 		onClose: React.PropTypes.func,
 		onOpen: React.PropTypes.func,
-		summary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] )
+		summary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ),
+		clickableHeader: React.PropTypes.bool,
+		clickableHeaderText: React.PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -43,7 +45,9 @@ var FoldableCard = React.createClass( {
 			onClose: noop,
 			cardKey: '',
 			icon: 'chevron-down',
-			isExpanded: false
+			isExpanded: false,
+			clickableHeader: false,
+			clickableHeaderText: false
 		};
 	},
 
@@ -111,14 +115,18 @@ var FoldableCard = React.createClass( {
 			header = this.props.header ? <div className="dops-foldable-card__header-text">{ this.props.header }</div> : null,
 			subheader = this.props.subheader ? <div className="dops-foldable-card__subheader">{ this.props.subheader }</div> : null,
 			headerClickAction = this.props.clickableHeader ? this.getClickAction() : null,
+			headerTextClickAction = this.props.clickableHeaderText ? this.getClickAction() : null,
 			headerClasses = classNames( 'dops-foldable-card__header', {
 				'is-clickable': !! this.props.clickableHeader,
 				'has-border': !! this.props.summary
+			} ),
+			headerTextClasses = classNames( 'dops-foldable-card__header-text', {
+				'is-clickable': !! this.props.clickableHeaderText
 			} );
 		return (
 			<div className={ headerClasses } onClick={ headerClickAction }>
 				<span className="dops-foldable-card__main">
-					<div>
+					<div className={ headerTextClasses } onClick={ headerTextClickAction } >
 						{ header }
 						{ subheader }
 					</div>

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -88,9 +88,9 @@ button.dops-foldable-card__action {
 
 .dops-foldable-card__main {
 	max-width: calc( 100% - 36px );
-	display: flex;
+	display: block;
 	align-items: center;
-	flex: 2 1;
+	width: 100%;
 	margin-right: 5px;
 
 	@include breakpoint( '<480px' ) {

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -15,6 +15,9 @@
 		margin-bottom: 8px;
 	}
 
+	.is-clickable {
+		cursor: pointer;
+	}
 }
 
 .dops-foldable-card__header {
@@ -26,10 +29,6 @@
 	align-items: center;
 	justify-content: space-between;
 	position: relative;
-
-	&.is-clickable {
-		cursor: pointer;
-	}
 
 	&.has-border{
 		.dops-foldable-card__summary,
@@ -134,10 +133,7 @@ button.dops-foldable-card__action {
 
 .dops-foldable-card__header-text {
 	font-size: rem( 18px );
-
-	&.is-clickable {
-		cursor: pointer;
-	}
+	width: 100%;
 }
 
 .dops-foldable-card__subheader {

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -134,6 +134,10 @@ button.dops-foldable-card__action {
 
 .dops-foldable-card__header-text {
 	font-size: rem( 18px );
+
+	&.is-clickable {
+		cursor: pointer;
+	}
 }
 
 .dops-foldable-card__subheader {


### PR DESCRIPTION
Sometimes, like in Jetpack when you already have a clickable item (toggle) in the header, you still want part of the header to be clickable and expand, but not the whole thing, as it would clash with the toggle.  This allows just the header text to be clickable.

Also adds the existing `clickableHeader` to the listed propTypes, as it was missing from there before.

To test: 
Get this branch linked to any Jetpack branch, and add `clickableHeaderText={ true }` to any `FoldableCard`