### PR TITLE
Enhancement: global notice adjustments

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -50,14 +50,14 @@ module.exports = React.createClass( {
 		let content;
 
 		if ( typeof this.props.children === 'string' ) {
-			return <span className="notice__text">{ this.props.children }</span>;
+			return <span className="dops-notice__text">{ this.props.children }</span>;
 		}
 
 		if ( this.props.text ) {
 			content = [ this.props.children ];
-			content.unshift( <span key="notice_text" className="notice__text">{ this.props.text }</span> );
+			content.unshift( <span key="dops-notice_text" className="dops-notice__text">{ this.props.text }</span> );
 		} else {
-			content = <span key="notice_text" className="notice__text">{ this.props.children }</span>;
+			content = <span key="dops-notice_text" className="dops-notice__text">{ this.props.children }</span>;
 		}
 
 		return content;
@@ -68,7 +68,7 @@ module.exports = React.createClass( {
 
 		// The class determines the nature of a notice
 		// and its status.
-		noticeClass = classNames( 'notice', this.props.status );
+		noticeClass = classNames( 'dops-notice', this.props.status );
 
 		if ( this.props.isCompact ) {
 			noticeClass = classNames( noticeClass, 'is-compact' );
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 		if ( this.props.showDismiss ) {
 			noticeClass = classNames( noticeClass, 'is-dismissable' );
 			dismiss = (
-				<Button className="notice__dismiss" onClick={ this.props.onClick } >
+				<Button className="dops-notice__dismiss" onClick={ this.props.onClick } >
 					<Gridicon icon="cross" size={ 24 } />
 					<ScreenReaderText>{ i18n.translate( 'Dismiss' ) }</ScreenReaderText>
 				</Button>

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -34,7 +34,7 @@
 			@extend %noticon;
 			content: '\f456';
 			position: absolute;
-				top: 26px;
+				top: 23px;
 				left: 20px;
 			margin: -12px 0px 0 -8px;
 			font-size: 24px;
@@ -42,8 +42,15 @@
 		}
 	}
 
-	.dops-notice__dismiss:focus {
-		box-shadow: 0 0 4px darken( $gray-light, 10 );
+	.dops-notice__dismiss {
+
+		&.dops-button .gridicon {
+			top: 0;
+		}
+
+		&:focus {
+			box-shadow: 0 0 4px darken( $gray-light, 10 );
+		}
 	}
 
 	// Success!

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -2,7 +2,7 @@
 @import '../../scss/layout';
 @import '../../scss/extends';
 
-.notice {
+.dops-notice {
 	flex: 1 100%;
 	display: flex;
 		flex-wrap: wrap;
@@ -15,7 +15,7 @@
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
 
-	.notice__text {
+	.dops-notice__text {
 		flex-grow: 1;
 		flex-basis: 100px;
 
@@ -42,7 +42,7 @@
 		}
 	}
 
-	.notice__dismiss:focus {
+	.dops-notice__dismiss:focus {
 		box-shadow: 0 0 4px darken( $gray-light, 10 );
 	}
 
@@ -50,7 +50,7 @@
 	&.is-success {
 		background: $alert-green;
 
-		.notice__dismiss:focus {
+		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 4px darken( $alert-green, 10 );
 		}
 
@@ -65,7 +65,7 @@
 	&.is-warning {
 		background: $alert-yellow;
 
-		.notice__dismiss:focus {
+		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 4px darken( $alert-yellow, 10 );
 		}
 
@@ -77,7 +77,7 @@
 	&.is-error {
 		background: $alert-red;
 
-		.notice__dismiss:focus {
+		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 4px darken( $alert-red, 10 );
 		}
 
@@ -89,7 +89,7 @@
 	&.is-info {
 		background: $blue-wordpress;
 
-		.notice__dismiss:focus {
+		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 4px darken( $blue-wordpress, 10 );
 		}
 
@@ -103,7 +103,7 @@
 
 // General styles for html elements
 // rendered inside a notice
-.notice {
+.dops-notice {
 
 	a,
 	button.is-link {
@@ -159,19 +159,19 @@
 			}
 		}
 
-		.notice__dismiss {
+		.dops-notice__dismiss {
 			color: $white;
 		}
 	}
 }
 
-.notice__button {
+.dops-notice__button {
 	cursor: pointer;
 	margin-left: 0.428em;
 }
 
 // "X" for dismissing a notice
-.notice__dismiss {
+.dops-notice__dismiss {
 	display: flex;
 	padding: 9px 16px;
 	cursor: pointer;
@@ -190,7 +190,7 @@
 		color: $gray-dark;
 	}
 
-	.notice & {
+	.dops-notice & {
 		color: $gray;
 		opacity: 0.85;
 
@@ -202,11 +202,11 @@
 }
 
 // Compact notices
-.notice.is-compact {
+.dops-notice.is-compact {
 	margin-bottom: 8px;
 	font-size: 14px;
 
-	.notice__text {
+	.dops-notice__text {
 		padding: 11px 0px 11px 16px;
 	}
 
@@ -214,11 +214,11 @@
 		display: none;
 	}
 
-	.notice__dismiss {
+	.dops-notice__dismiss {
 		padding: 9px 16px;
 	}
 
-	a.notice__arrow-link .gridicon {
+	a.dops-notice__arrow-link .gridicon {
 		width: 18px;
 		height: 18px;
 	}
@@ -226,7 +226,7 @@
 
 // ArrowLink sub-component
 // specificity for general `a` elements within notice is too great
-.notice a.notice__arrow-link {
+.dops-notice a.dops-notice__arrow-link {
 	background: rgba( 0, 0, 0, 0.2 );
 	box-sizing: border-box;
 	color: $white;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -145,7 +145,7 @@
 		margin-left: 8px;
 		text-align: left;
 		line-height: 1.4285;
-		font-weight: 600;
+		font-weight: 400;
 		text-decoration: underline;
 
 		// @media not all, only screen and (min-resolution: 2dppx), only screen and (-webkit-min-device-pixel-ratio: 2) {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -111,6 +111,8 @@
 	&.is-basic {
 		background: $white;
 		color: $gray;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+				0 1px 2px lighten( $gray, 30% );
 
 		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -106,6 +106,31 @@
 			}
 		}
 	}
+
+	// Basic - Unobtrusive, no icon
+	&.is-basic {
+		background: $white;
+		color: $gray;
+
+		.dops-notice__dismiss:focus {
+			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+				0 1px 2px lighten( $gray, 30% );
+		}
+
+		@include breakpoint( ">660px" ) {
+			&:before {
+				display: none;
+			}
+		}
+
+		.dops-notice__text {
+			padding: 11px 24px;
+
+			@include breakpoint( ">660px" ) {
+				padding: 13px;
+			}
+		}
+	}
 }
 
 // General styles for html elements


### PR DESCRIPTION
Made a couple of small adjustments in regard to naming conventions of notices and icon position. 

Changed the name of `.notice` to `.dops-notice` since the general `.notice` class name is used by core, and potentially other plugins, which could make it fairly susceptible to style bleeding. 

Fixing issues in: https://github.com/Automattic/jetpack/pull/3974
Related changes: https://github.com/Automattic/akismet-react/pull/20

Before:
![screen shot 2016-05-24 at 2 08 19 pm](https://cloud.githubusercontent.com/assets/214813/15514674/311982bc-21b8-11e6-91f1-010ef3730488.png)


After:
![screen shot 2016-05-26 at 10 44 59 am](https://cloud.githubusercontent.com/assets/214813/15578335/10e67172-232e-11e6-9453-c21aaacc9c4f.png)
