### PR TITLE
Chart Tooltip: fixes misalignment in arrow tip

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -378,7 +378,7 @@
 				border: 4px solid $transparent;
 				border-bottom-color: darken( $gray, 30% );
 				position: absolute;
-					left: 231px  #{"/*rtl:ignore*/"};
+					left: 211px  #{"/*rtl:ignore*/"};
 					top: -3px;
 
 				.rtl & {


### PR DESCRIPTION
**Before**
<img width="332" alt="before" src="https://cloud.githubusercontent.com/assets/1041600/15559978/4f82a804-22bd-11e6-8675-269c3b5fdd18.png">
**After**
<img width="283" alt="after" src="https://cloud.githubusercontent.com/assets/1041600/15559979/4f8939f8-22bd-11e6-9a9b-b8ee31bd1002.png">