### PR TITLE
Notices: change the icons used from Noticons to Dashicons.

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -31,8 +31,8 @@
 		font-size: inherit;
 
 		&::before {
-			@extend %noticon;
-			content: '\f456';
+			@extend %dashicon;
+			content: '\f534';
 			position: absolute;
 				top: 23px;
 				left: 20px;
@@ -63,7 +63,7 @@
 
 		@include breakpoint( ">660px" ) {
 			&:before {
-				content: '\f418';
+				content: '\f147';
 			}
 		}
 	}
@@ -102,7 +102,7 @@
 
 		@include breakpoint( ">660px" ) {
 			&:before {
-				content: '\f455';
+				content: '\f348';
 			}
 		}
 	}

--- a/client/scss/extends.scss
+++ b/client/scss/extends.scss
@@ -12,6 +12,13 @@
 	vertical-align: middle;
 }
 
+%dashicon {
+	@extend %clear-text;
+	display: inline-block;
+	font: normal 16px/1 'Dashicons';
+	vertical-align: middle;
+}
+
 %container {
 	position: relative;
 	margin-bottom: 6%;


### PR DESCRIPTION
<img width="315" alt="dashicons1" src="https://cloud.githubusercontent.com/assets/1041600/15727040/8b38dc2a-282a-11e6-973d-c1a33d4171dd.png">
<img width="217" alt="dashicons2" src="https://cloud.githubusercontent.com/assets/1041600/15727041/8b4196a8-282a-11e6-933c-8d5d957a2e86.png">
<img width="234" alt="dashicons3" src="https://cloud.githubusercontent.com/assets/1041600/15727042/8b458088-282a-11e6-8fbf-93895b254920.png">
<img width="231" alt="dashicons4" src="https://cloud.githubusercontent.com/assets/1041600/15727043/8b47ad2c-282a-11e6-9560-1e866afa7e45.png">

- The warning and error icons were the same from before this PR.
- If this is added, maybe we don't need to add https://github.com/Automattic/jetpack/pull/4040. We might add the portion that makes the function `wpcom_static_url` visible throughout the Jetpack plugin, but it might not be necessary to add the line that enqueues the icons in the Jetpack React UI.