### PR TITLE
Removes default WordPress admin focus styles on a few elements.

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -51,6 +51,7 @@
 		}
 	}
 	&:focus {
+		outline: 0;
 		border-color: $blue-medium;
 		box-shadow: 0 0 0 2px $blue-light;
 	}

--- a/client/components/form/form-toggle/style.scss
+++ b/client/components/form/form-toggle/style.scss
@@ -41,7 +41,8 @@
 	&:hover {
 		background: lighten( $gray, 20% );
 	}
-	.accessible-focus &:focus{
+	.accessible-focus &:focus,
+	&:focus {
 		box-shadow: 0 0 0 2px $blue-medium;
 	}
 }

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -282,6 +282,8 @@
 
 	&:focus {
 		outline: none;
+		box-shadow: none;
+
 		.accessible-focus & {
 			outline: solid $gray 1px;
 		}


### PR DESCRIPTION
Helps resolve https://github.com/Automattic/jetpack/issues/3900

Fixes:
* Button
* Form-toggle (actually adds one back in)
* SectionNav

Note: leaves normal link focus styles in tact for now.