### PR TITLE
Fix section nav dropdowns on smaller screens

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -3,6 +3,7 @@
 @import '../../scss/mixin_breakpoint';
 @import '../../scss/rem';
 @import '../../scss/z-index';
+@import '../../scss/extends';
 
 /**
  * Section Nav
@@ -58,14 +59,16 @@
 	cursor: pointer;
 
 	&:after {
-		// @include noticon( '\f431', 20px );
+		@extend %dashicon;
+		content: '\f347';
 		line-height: 16px;
 		color: rgba( $gray, 0.5 );
 	}
 
 	.dops-section-nav.is-open & {
 		&:after {
-			content: '\f432';
+			@extend %dashicon;
+			content: '\f343';
 		}
 	}
 
@@ -140,7 +143,7 @@
 	@include breakpoint( "<480px" ) {
 		display: none;
 
-		.section-nav.is-open & {
+		.dops-section-nav.is-open & {
 			display: block;
 		}
 	}

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -173,7 +173,7 @@ class SelectDropdown extends Component {
 
 	render() {
 		const dropdownClasses = {
-			'select-dropdown': true,
+			'dops-select-dropdown': true,
 			'is-compact': this.props.compact,
 			'is-open': this.state.isOpen
 		};

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -2,6 +2,7 @@
 @import '../../scss/z-index';
 @import '../../scss/rem';
 @import '../../scss/z-index';
+@import '../../scss/extends';
 
 /**
  * Select Dropdown
@@ -59,7 +60,8 @@
 	cursor: pointer;
 
 	&::after {
-		// @include noticon('\f431', 22px);
+		@extend %dashicon;
+		content: '\f347';
 		position: absolute;
 			right: 13px;
 			top: 12px;
@@ -95,7 +97,8 @@
 		background-color: $gray-light;
 
 		&::after {
-			content: '\f432';
+			@extend %dashicon;
+			content: '\f343';
 		}
 	}
 


### PR DESCRIPTION
![section-nav-demo](https://cloud.githubusercontent.com/assets/7129409/16672590/1d603434-4475-11e6-88db-77b37dfa5065.gif)

Before, section nav was completely broken when you got to smaller viewports.  This fixes both instances for viewports `above 480px` and `below 480px`.

This also updates the styles to use dashicons to show the arrows.  

To test: 
- Link this branch to https://github.com/Automattic/jetpack/pull/4339
- Follow the instructions in that PR. 