### PR TITLE
Fix scss @extend errors on compile

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -14,6 +14,7 @@
 	font-size: 14px;
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
+	@extend %dashicon;
 
 	.dops-notice__text {
 		flex-grow: 1;
@@ -31,7 +32,6 @@
 		font-size: inherit;
 
 		&::before {
-			@extend %dashicon;
 			content: '\f534';
 			position: absolute;
 				top: 23px;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -14,7 +14,10 @@
 	font-size: 14px;
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
-	@extend %dashicon;
+
+	&::before{
+		@extend %dashicon;
+	}
 
 	.dops-notice__text {
 		flex-grow: 1;

--- a/client/scss/calypso-form.scss
+++ b/client/scss/calypso-form.scss
@@ -1,5 +1,6 @@
 // Below, you can choose from either using global form styles or class-driven
 // form styles. By default, the global styles are on.
+@import 'extends';
 
 %form {
 	ul {


### PR DESCRIPTION
@extend cannot be used within a media breakpoint without causing errors.

To test: 
- You should see no more errors on compile related to extend when trying to compile akismet react
- Notices should still show icons correctly.  