### PR TITLE
Update notices to current calypso

### DIFF
--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+	displayName: 'NoticeAction',
+
+	propTypes: {
+		href: React.PropTypes.string,
+		onClick: React.PropTypes.func,
+		external: React.PropTypes.bool,
+		icon: React.PropTypes.string
+	},
+
+	getDefaultProps() {
+		return {
+			external: false
+		};
+	},
+
+	render() {
+		const attributes = {
+			className: 'notice__action',
+			href: this.props.href,
+			onClick: this.props.onClick
+		};
+
+		if ( this.props.external ) {
+			attributes.target = '_blank';
+		}
+
+		return (
+			<a {...attributes} >
+				<span>{ this.props.children }</span>
+				{ this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
+				{ this.props.external && <Gridicon icon="external" size={ 24 } /> }
+			</a>
+		);
+	}
+} );

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -3,107 +3,51 @@
 @import '../../scss/extends';
 
 .dops-notice {
-	flex: 1 100%;
 	display: flex;
-		flex-wrap: wrap;
 	position: relative;
 	margin-bottom: 24px;
 	border-radius: 1px;
-	background: $gray-light;
+	background: lighten( $gray, 30 );
 	box-sizing: border-box;
 	font-size: 14px;
-	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
-
-	.dops-notice__text {
-		flex-grow: 1;
-		flex-basis: 100px;
-
-		padding: 11px 24px;
-		padding-right: 0;
-
-		@include breakpoint( ">660px" ) {
-			padding: 13px 48px;
-		}
-	}
 
 	@include breakpoint( ">660px" ) {
 		font-size: inherit;
-
-		&::before {
-			@extend %dashicon;
-			content: '\f534';
-			position: absolute;
-				top: 23px;
-				left: 20px;
-			margin: -12px 0px 0 -8px;
-			font-size: 24px;
-			line-height: 1;
-		}
-	}
-
-	.dops-notice__dismiss {
-
-		&.dops-button .gridicon {
-			top: 0;
-		}
-
-		&:focus {
-			box-shadow: 0 0 4px darken( $gray-light, 10 );
-		}
 	}
 
 	// Success!
 	&.is-success {
 		background: $alert-green;
-
-		.dops-notice__dismiss:focus {
-			box-shadow: 0 0 4px darken( $alert-green, 10 );
-		}
-
-		@include breakpoint( ">660px" ) {
-			&:before {
-				content: '\f147';
-			}
-		}
 	}
 
 	// Warning
 	&.is-warning {
 		background: $alert-yellow;
-
-		.dops-notice__dismiss:focus {
-			box-shadow: 0 0 4px darken( $alert-yellow, 10 );
-		}
-
-		&:before {
-		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
 		background: $alert-red;
-
-		.dops-notice__dismiss:focus {
-			box-shadow: 0 0 4px darken( $alert-red, 10 );
-		}
-
-		&:before {
-		}
 	}
 
-	// Information
+	// General notice
 	&.is-info {
 		background: $blue-wordpress;
+	}
 
-		.dops-notice__dismiss:focus {
-			box-shadow: 0 0 4px darken( $blue-wordpress, 10 );
+	&.is-success,
+	&.is-error,
+	&.is-warning,
+	&.is-info {
+		color: $white;
+
+		.dops-notice__text a {
+			color: $white;
 		}
 
-		@include breakpoint( ">660px" ) {
-			&:before {
-				content: '\f348';
-			}
+		.dops-notice__dismiss {
+			color: $white;
 		}
 	}
 
@@ -112,11 +56,11 @@
 		background: $white;
 		color: $gray;
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-				0 1px 2px lighten( $gray, 30% );
+		0 1px 2px lighten( $gray, 30% );
 
 		.dops-notice__dismiss:focus {
 			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-				0 1px 2px lighten( $gray, 30% );
+			0 1px 2px lighten( $gray, 30% );
 		}
 
 		@include breakpoint( ">660px" ) {
@@ -135,23 +79,39 @@
 	}
 }
 
-// General styles for html elements
-// rendered inside a notice
-.dops-notice {
+.dops-notice__icon {
+	flex-shrink: 0;
+	padding: 13px 0 13px 16px;
 
-	a,
-	button.is-link {
-		display: inline;
-		margin-left: 8px;
-		text-align: left;
-		line-height: 1.4285;
-		font-weight: 400;
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+.dops-notice__content {
+	display: flex;
+	flex-grow: 1;
+
+	@include breakpoint( "<480px" ) {
+		flex-direction: column;
+	}
+}
+
+.dops-notice__text {
+	font-size: 15px;
+	padding: 11px 24px;
+
+	& > span,
+	& > div {
+		max-width: 680px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		padding: 13px;
+	}
+
+	a {
 		text-decoration: underline;
-
-		// @media not all, only screen and (min-resolution: 2dppx), only screen and (-webkit-min-device-pixel-ratio: 2) {
-		// 	background-image: linear-gradient(to bottom, rgba(0,0,0,0) 75%, #fff 75%);
-		// 	background-repeat: repeat-x;
-		// }
 	}
 
 	ul {
@@ -172,31 +132,6 @@
 			margin-top: 0;
 		}
 	}
-
-	&.is-success, // TODO fix this in pre-oss to be less bad
-	&.is-error,
-	&.is-warning,
-	&.is-info {
-		color: $white;
-
-		span {
-			color: inherit;
-		}
-
-		a,
-		button.is-link {
-			color: rgba( $white, 0.85 );
-
-			&:hover,
-			&:focus {
-				color: $white;
-			}
-		}
-
-		.dops-notice__dismiss {
-			color: $white;
-		}
-	}
 }
 
 .dops-notice__button {
@@ -207,13 +142,10 @@
 // "X" for dismissing a notice
 .dops-notice__dismiss {
 	display: flex;
-	padding: 9px 16px;
+	flex-shrink: 0;
+	padding: 11px 16px;
 	cursor: pointer;
 	color: $gray;
-
-	background: transparent;
-	border: none;
-	border-radius: 0;
 
 	@include breakpoint( ">660px" ) {
 		padding: 13px 16px;
@@ -235,51 +167,112 @@
 	}
 }
 
-// Compact notices
-.dops-notice.is-compact {
-	margin-bottom: 8px;
-	font-size: 14px;
-
-	.dops-notice__text {
-		padding: 11px 0px 11px 16px;
-	}
-
-	&::before {
-		display: none;
-	}
-
-	.dops-notice__dismiss {
-		padding: 9px 16px;
-	}
-
-	a.dops-notice__arrow-link .gridicon {
-		width: 18px;
-		height: 18px;
-	}
-}
-
-// ArrowLink sub-component
 // specificity for general `a` elements within notice is too great
-.dops-notice a.dops-notice__arrow-link {
-	background: rgba( 0, 0, 0, 0.2 );
-	box-sizing: border-box;
-	color: $white;
-	cursor: pointer;
+a.dops-notice__action {
 	display: flex;
-		align-items: center;
+	align-items: center;
+	flex-shrink: 0;
+	box-sizing: border-box;
+	cursor: pointer;
+	font-size: 15px;
 	font-weight: 400;
-	line-height: 1.2;
 	margin-left: auto; // forces the element to the right;
-	padding: 13px 10px 13px 16px;
+	padding: 13px 16px;
 	text-decoration: none;
 	white-space: nowrap;
 
+	.is-success &,
+	.is-error &,
+	.is-warning &,
+	.is-info & {
+		color: $white;
+	}
+
+	.is-success & { background: darken( $alert-green, 15 ); }
+	.is-error & { background: darken( $alert-red, 15 ); }
+	.is-warning & { background: darken( $alert-yellow, 15 ); }
+	.is-info & { background: darken( $blue-wordpress, 15 ); }
+
 	.gridicon {
 		margin-left: 8px;
+		opacity: 0.7;
 	}
 
 	&:hover,
 	&:focus {
 		background: rgba( 255, 255, 255, 0.2 );
 	}
+
+	@include breakpoint( "<480px" ) {
+		margin: 0;
+		justify-content: flex-end;
+	}
 }
+
+// Compact notices
+.dops-notice.is-compact {
+	border-radius: 2px;
+	display: inline-flex;
+	flex-wrap: nowrap;
+	min-height: 20px;
+	margin: 0;
+	padding: 0;
+	text-decoration: none;
+	text-transform: none;
+	vertical-align: middle;
+
+	&.is-success,
+	&.is-error,
+	&.is-warning,
+	&.is-info {
+		color: $white;
+	}
+
+	.dops-notice__text {
+		font-size: 12px;
+		padding: 6px 8px;
+		line-height: 1;
+	}
+
+	.dops-notice__icon {
+		align-self: center;
+		flex-shrink: 0;
+		margin: 0 0 0 8px;
+		padding: 0;
+		width: 18px;
+		height: 18px;
+		vertical-align: middle;
+	}
+
+	.dops-notice__dismiss {
+		display: none;
+	}
+
+	a.dops-notice__action {
+		background: transparent;
+		display: inline-block;
+		font-size: 11px;
+		font-weight: 600;
+		align-self: center;
+		margin-left: 16px;
+		padding: 0 8px;
+		text-decoration: underline;
+		text-transform: uppercase;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: transparent;
+			text-decoration: none;
+		}
+
+		.gridicon {
+			margin-left: 8px;
+			width: 14px;
+			height: 14px;
+			vertical-align: sub;
+			opacity: 1;
+		}
+	}
+}
+


### PR DESCRIPTION
This PR seeks to update the notices to current Calypso.  

- Adds notice actions
- Adds compact styles && matching calypso styles.  
- Changes the dismiss onClick propname to `onDismissClick`

To test: 
- npm link this and test your notices.  They should look the same.  The onClick for dismiss should be expected to be broken.  Will fix that in another PR once this is merged.  
