### PR TITLE
Require react instead of react/addons to eliminate JS warnings

### DIFF
--- a/client/components/form/form-toggle/index.jsx
+++ b/client/components/form/form-toggle/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 var idNum = 0;


### PR DESCRIPTION
react/addons is deprecated and throws `Warning: require('react/addons') is deprecated. Access using require('react-addons-{addon}') instead.` when it's used.

We should patch all files but since we're close to the alpha I've solved this one for now which is the one throwing a warning in JPR.

To test, fetch the branch and in command line, go to `dops-components` directory and run 
```
npm link
```
go to `jetpack` plugin directory and run
```
npm link @automattic/dops-components
```