### PR TITLE
SectionHeader: moved cardBadge location

### DIFF
--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -44,8 +44,8 @@ export default React.createClass( {
 			<Card compact className={ classes }>
 				<div className="dops-section-header__label">
 					{ this.props.label }
+					{ maybeShowCardBadge }
 				</div>
-				{ maybeShowCardBadge }
 				<div className="dops-section-header__actions">
 					{ this.props.children }
 				</div>

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -33,7 +33,7 @@
 }
 
 .dops-section-header__card-badge {
-	margin-right: rem( 8px );
+	margin-left: rem( 8px );
 }
 
 .dops-section-header__actions {


### PR DESCRIPTION
Moves the badges from the right section to the left next to the title as designed.

CC @dereksmart or @jeffgolenski for review