### PR TITLE
Chart:  Use Dashicon for emtpy stats icon.

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -7,6 +7,7 @@
 @import '../../scss/mixin_clear-fix';
 @import '../../scss/mixin_long-content-fade';
 @import '../../scss/z-index';
+@import '../../scss/extends';
 
 .dops-chart {
 	position: relative;
@@ -346,8 +347,8 @@
 		font-size: inherit;
 
 		&::before {
-			@extend %noticon;
-			content: '\f456';
+			@extend %dashicon;
+			content: '\f348';
 			position: absolute;
 				top: 23px;
 				left: 20px;


### PR DESCRIPTION
fixes https://github.com/Automattic/jetpack/issues/4487

To test: 
- npm link dops-components and hack [this conditional](https://github.com/Automattic/dops-components/blob/master/client/components/chart/index.jsx#L126) to say `true`
- See that there is an icon