### PR TITLE
Checkbox: added full checkbox component with Calypso styles

### DIFF
--- a/client/components/checkbox/README.md
+++ b/client/components/checkbox/README.md
@@ -1,0 +1,21 @@
+Checkbox
+=========
+
+This component is used to implement some nifty checkboxes.
+
+#### How to use:
+
+```js
+var Checkbox = require( 'components/checkbox' );
+
+render: function() {
+	return (
+		<Checkbox compact primary disabled={ this.props.disabled } />
+	);
+}
+```
+
+#### Props
+
+* `checked`: (bool) whether the checkbox should be in the checked state.
+* `disabled`: (bool) whether the checkbox should be in the disabled state.

--- a/client/components/checkbox/index.jsx
+++ b/client/components/checkbox/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	classnames = require( 'classnames' ),
+	omit = require( 'lodash/omit' );
+
+require( './style.scss' );
+
+module.exports = React.createClass( {
+
+	displayName: 'Checkbox',
+
+	propTypes: {
+		disabled: React.PropTypes.bool,
+		checked: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			disabled: false
+		};
+	},
+
+	render: function() {
+		var otherProps = omit( this.props, [ 'className', 'type' ] );
+
+		return (
+			<input { ...otherProps } type="checkbox" className={ classnames( this.props.className, 'dops-checkbox' ) } />
+		);
+	}
+} );

--- a/client/components/checkbox/style.scss
+++ b/client/components/checkbox/style.scss
@@ -1,0 +1,75 @@
+@import '../../scss/calypso-colors';
+@import '../../scss/rem';
+
+// ==========================================================================
+// Checkboxes
+// ==========================================================================
+
+.dops-checkbox.dops-checkbox {
+	display: inline-block;
+	box-sizing: border-box;
+	margin: 2px 0 0;
+	padding: 7px 14px;
+	width: 16px;
+	height: 16px;
+	float: left;
+	outline: 0;
+	padding: 0;
+	box-shadow: none;
+	background-color: $white;
+	border: 1px solid lighten( $gray, 20% );
+	color: $gray-dark;
+	font-size: 16px;
+	line-height: 0;
+	text-align: center;
+	vertical-align: middle;
+	appearance: none;
+	transition: all .15s ease-in-out;
+	clear: none;
+	cursor: pointer;
+
+	&:checked:before {
+		content: '\f418';
+		margin: -4px 0 0 -5px;
+		float: left;
+		display: inline-block;
+		vertical-align: middle;
+		width: 16px;
+		font: 400 23px/1 Noticons;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		speak: none;
+		color: $blue-medium;
+	}
+
+	&:disabled:checked:before {
+		color: lighten( $gray, 10% );
+	}
+
+	&:hover {
+		border-color: lighten( $gray, 10% );
+	}
+
+	&:focus {
+		border-color: $blue-wordpress;
+		outline: none;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+
+	&:disabled {
+		background: $gray-light;
+		border-color: lighten( $gray, 30% );
+		color: lighten( $gray, 10% );
+		opacity: 1;
+
+		&:hover {
+			cursor: default;
+		}
+	}
+
+	// I would like to remove this, but might break things - MJA
+	+ span {
+		display: block;
+		margin-left: 24px;
+	}
+}


### PR DESCRIPTION
This pulls in the Checkbox styles and work done [here](https://github.com/Automattic/wp-calypso/pull/5323) in an initial commit. We can still use the old FormCheckbox component in the meantime while we switch over. (better than a big PR).

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17148217/2e985cb8-5334-11e6-8478-915d02d938c6.png)
![image](https://cloud.githubusercontent.com/assets/1123119/17148221/365fa1e0-5334-11e6-9d66-a361824d4981.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17148165/f6fb67e6-5333-11e6-80a2-4ddce187431f.png)
