### PR TITLE
Checkbox: fixed to use dashicons instead of noticons for now

### DIFF
--- a/client/components/checkbox/style.scss
+++ b/client/components/checkbox/style.scss
@@ -29,13 +29,13 @@
 	cursor: pointer;
 
 	&:checked:before {
-		content: '\f418';
-		margin: -4px 0 0 -5px;
+		content: '\f147'; // Dashicons
+		margin: -3px 0 0 -4px;
 		float: left;
 		display: inline-block;
 		vertical-align: middle;
 		width: 16px;
-		font: 400 23px/1 Noticons;
+		font-size: 20px;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
 		speak: none;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/4655

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17502958/07eec9a4-5dba-11e6-854c-d37868a5f6d5.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17502918/be5862fa-5db9-11e6-849d-41f0d3517a38.png)


CC @oskosk for review