### PR TITLE
Add/search collection

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -92,7 +92,7 @@ const Search = React.createClass( {
 				: this.props.onSearch;
 		}
 
-		if ( nextProps.isOpen ) {
+		if ( nextProps.isOpen !== this.props.isOpen ) {
 			this.setState( { isOpen: nextProps.isOpen } );
 		}
 	},

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -41,6 +41,7 @@ const Search = React.createClass( {
 		onSearch: React.PropTypes.func.isRequired,
 		onSearchChange: React.PropTypes.func,
 		onSearchClose: React.PropTypes.func,
+		onSearchOpen: React.PropTypes.func,
 		analyticsGroup: React.PropTypes.string,
 		autoFocus: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
@@ -67,6 +68,7 @@ const Search = React.createClass( {
 			disabled: false,
 			onSearchChange: noop,
 			onSearchClose: noop,
+			onSearchOpen: noop,
 			onKeyDown: noop,
 			disableAutocorrect: false,
 			searching: false,
@@ -168,6 +170,8 @@ const Search = React.createClass( {
 			keyword: '',
 			isOpen: true
 		} );
+
+		this.props.onSearchOpen();
 	},
 
 	closeSearch: function( event ) {

--- a/client/components/search/search-collection.jsx
+++ b/client/components/search/search-collection.jsx
@@ -23,9 +23,19 @@ const Hider = React.createClass( {
 } );
 
 const FilterSummary = React.createClass( {
+	getDefaultProps: function() {
+		return {
+			noResultsText: 'No Results Found'
+		};
+	},
+
+	propTypes: {
+		noResultsText: React.PropTypes.string
+	},
+
 	render() {
 		if ( this.props.items.length === 0 ) {
-			return ( <p>No results found.</p> );
+			return ( <p>{ this.props.noResultsText }</p> );
 		} else {
 			return null;
 		}
@@ -74,7 +84,9 @@ export default React.createClass( {
 			summary = (
 				<FilterSummary
 					items={ this.visibleExamples( examples ) }
-					total={ this.props.children.length } />
+					total={ this.props.children.length }
+					noResultsText={ this.props.noResultsText }
+				/>
 			);
 		}
 

--- a/client/components/search/search-collection.jsx
+++ b/client/components/search/search-collection.jsx
@@ -10,10 +10,6 @@ const Hider = React.createClass( {
 		hide: React.PropTypes.bool,
 	},
 
-	shouldComponentUpdate( nextProps ) {
-		return this.props.hide !== nextProps.hide;
-	},
-
 	render() {
 		return (
 			<div

--- a/client/components/search/search-collection.jsx
+++ b/client/components/search/search-collection.jsx
@@ -1,0 +1,92 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+const Hider = React.createClass( {
+	displayName: 'Hider',
+
+	propTypes: {
+		hide: React.PropTypes.bool,
+	},
+
+	shouldComponentUpdate( nextProps ) {
+		return this.props.hide !== nextProps.hide;
+	},
+
+	render() {
+		return (
+			<div
+				className={ 'design-assets__group' }
+				style={ this.props.hide ? { display: 'none' } : {} }
+			>
+				{ this.props.children }
+			</div>
+		);
+	}
+} );
+
+const FilterSummary = React.createClass( {
+	render() {
+		if ( this.props.items.length === 0 ) {
+			return ( <p>No results found.</p> );
+		} else {
+			return null;
+		}
+	}
+} );
+
+export default React.createClass( {
+	displayName: 'Collection',
+
+	shouldWeHide: function( example ) {
+		let filter, searchString;
+
+		filter = this.props.filter || '';
+
+		searchString = example.props.searchTerms;
+
+		if ( this.props.component ) {
+			return example.type.displayName.toLowerCase() !== this.props.component.replace( /-([a-z])/g, '$1' );
+		}
+
+		if ( example.props.searchKeywords ) {
+			searchString += ' ' + example.props.searchKeywords;
+		}
+
+		return ! ( ! filter || searchString.toLowerCase().indexOf( filter ) > -1 );
+	},
+
+	visibleExamples: function( examples ) {
+		return examples.filter( ( child ) => {
+			return !child.props.hide;
+		} );
+	},
+
+	render: function() {
+		let summary, examples;
+
+		examples = React.Children.map( this.props.children, ( example ) => {
+			return (
+				<Hider hide={ this.shouldWeHide( example ) } key={ 'example-' + example.type.displayName }>
+					{ example }
+				</Hider>
+			);
+		} );
+
+		if ( ! this.props.component ) {
+			summary = (
+				<FilterSummary
+					items={ this.visibleExamples( examples ) }
+					total={ this.props.children.length } />
+			);
+		}
+
+		return (
+			<div className="collection">
+				{ summary }
+				{ examples }
+			</div>
+		);
+	}
+} );


### PR DESCRIPTION
This adds the `SearchCollection` components from calypso.  It allows you to next children within it, which then are searchable using the `searchTerm` prop. 

To test: 
- Link to `add/search` branch in Jetpack repo, and search for some module terms.  