### PR TITLE
Search Collection: make sure to update isOpen state via the isOpen prop

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -90,7 +90,7 @@ const Search = React.createClass( {
 				: this.props.onSearch;
 		}
 
-		if ( nextProps.isOpen ) {
+		if ( nextProps.isOpen !== this.props.isOpen ) {
 			this.setState( { isOpen: nextProps.isOpen } );
 		}
 	},


### PR DESCRIPTION
That makes sure that the `isOpen` prop that is passed down updates the `isOpen` state, and thus updating the classes.  

To Test:
- Link to https://github.com/Automattic/jetpack/pull/4694, open/close the search.  Search should be open/closed as expected
- Open search and then go `back` in the browser. The search should be closed.  