### PR TITLE
TextInput: removed box shadow inherited from wp-admin styles

### DIFF
--- a/client/components/text-input/style.scss
+++ b/client/components/text-input/style.scss
@@ -17,7 +17,7 @@
 	border: 1px solid lighten( $gray, 20% );
 	background-color: $white;
 	transition: all .15s ease-in-out;
-	box-sizing: border-box;
+	box-shadow: none;
 
 	&::placeholder {
 		color: $gray;


### PR DESCRIPTION
Looks like we had a sneaky box shadow make its way onto our input. (Ignore the spacing on the copy button. Fixing that shortly)

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17678508/6866cc64-6305-11e6-9fc0-f9526c934158.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17678466/33979d24-6305-11e6-8883-283eea820623.png)
