### PR TITLE
ClipboardButton: fixes position of button

### DIFF
--- a/client/components/clipboard-button-input/style.scss
+++ b/client/components/clipboard-button-input/style.scss
@@ -2,6 +2,7 @@
 
 .dops-clipboard-button-input {
 	position: relative;
+	display: block;
 
 	.dops-clipboard-button {
 		position: absolute;


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17678619/da8a9b0e-6305-11e6-9964-f200f558d089.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17678607/cbf61cc6-6305-11e6-8165-b66e015007b5.png)
