### PR TITLE
FoldableCard: removed outline in favor of changing chevron color

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -84,6 +84,7 @@
 
 button.dops-foldable-card__action {
 	cursor: pointer;
+	outline: 0;
 }
 
 .dops-foldable-card__main {
@@ -126,8 +127,11 @@ button.dops-foldable-card__action {
 		fill: $gray;
 	}
 
-	&:hover .gridicon {
-		fill: $blue-medium;
+	&:focus,
+	&:hover {
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 }
 


### PR DESCRIPTION
To Test:
* go to a setting and click the expand button

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17679242/947bde22-6308-11e6-8c15-540c54279d20.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17679227/8157af7e-6308-11e6-90cb-c3dc14fed596.png)
