### PR TITLE
Search: remove inherited box shadow and margin

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -107,6 +107,7 @@
 	position: absolute;
 	z-index: z-index( '.dops-search', '.dops-search__input' );
 	top: 0;
+	margin: 0;
 	padding: 0 50px 0 60px;
 	border: none;
 	background: $white;
@@ -114,6 +115,7 @@
 	appearance: none;
 	box-sizing: border-box;
 	-webkit-appearance: none;
+	box-shadow: none;
 
 	@include breakpoint( "<660px" ) {
 		opacity: 0;


### PR DESCRIPTION
@dereksmart Can you spot the differences?

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17713374/912f83b6-63c8-11e6-9390-6027e2ed3ccd.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17713362/7d427e76-63c8-11e6-8137-b2658b80a8ee.png)
