### PR TITLE
Adds ExternalLink component

### DIFF
--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -1,0 +1,35 @@
+External Link
+=======
+
+External Link is a React component for rendering an external link.
+
+## Usage
+
+```jsx
+
+import React from 'react';
+import ExternalLink from 'components/external-link';
+
+React.createClass( {
+	render() {
+		return <ExternalLink icon={ true } href="https://wordpress.org" onClick="somefunction()">WordPress.org</ExternalLink>;
+	}
+} );
+```
+
+## Props
+The following props can be passed to the External Link component:
+
+### `icon`
+
+<table>
+	<tr><td>Type</td><td>Bool</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Set to true if you want to render a nice external Gridicon at the end of link.
+
+
+## Other Props
+Any other props that you pass into the `a` tag will be rendered as expected.
+For example `onClick` and `href`.

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classnames from 'classnames';
+import { assign, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+require( './style.scss' );
+
+export default React.createClass( {
+
+	displayName: 'ExternalLink',
+
+	mixins: [ PureRenderMixin ],
+
+	propTypes: {
+		className: React.PropTypes.string,
+		href: React.PropTypes.string,
+		onClick: React.PropTypes.func,
+		icon: React.PropTypes.bool,
+		iconSize: React.PropTypes.number
+	},
+
+	getDefaultProps() {
+		return {
+			iconSize: 18
+		};
+	},
+
+	render() {
+		const classes = classnames( 'dops-external-link', this.props.className, {
+			'has-icon': !! this.props.icon,
+		} );
+
+		const props = assign( {}, omit( this.props, 'icon', 'iconSize' ), {
+			className: classes,
+			rel: 'external'
+		} );
+
+		return (
+			<a { ...props }>
+				{ this.props.children }
+				{ this.props.icon ? <Gridicon icon="external" size={ this.props.iconSize } /> : null }
+			</a>
+		);
+	}
+} );

--- a/client/components/external-link/style.scss
+++ b/client/components/external-link/style.scss
@@ -1,0 +1,8 @@
+@import '../../scss/rem';
+
+.dops-external-link .gridicons-external {
+	color: currentColor;
+	margin-left: rem( 8px);
+	top: rem( 2px );
+	position: relative;
+}

--- a/client/components/external-link/style.scss
+++ b/client/components/external-link/style.scss
@@ -2,7 +2,7 @@
 
 .dops-external-link .gridicons-external {
 	color: currentColor;
-	margin-left: rem( 8px);
+	margin-left: rem( 8px );
 	top: rem( 2px );
 	position: relative;
 }


### PR DESCRIPTION
Pulls in the ExternalLink component from Calypso.

To test:
go to <adding shortly>

Looks like this:
![image](https://cloud.githubusercontent.com/assets/1123119/17740742/aafd419e-6467-11e6-9460-97fa13128115.png)
