### PR TITLE
ExternalLink component: Import only specific lodash methods in ExternalLink component.

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
-import { assign, omit } from 'lodash';
+import assign from 'lodash/assign';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Importing lodash globally, even when using destructuring the required methods, creates the window._ variable which may collapse with underscore as is the case inside a WordPress enviornment