### PR TITLE
Global Notices: fix z-index so it doesn't conflict with search icon z-index

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -1,13 +1,13 @@
 @import "../../scss/calypso-colors";
 @import "../../scss/calypso-mixins";
+@import '../../scss/z-index';
 
 .global-notices {
 	overflow: hidden;
 	text-align: right;
 	//pointer-events: none;
 
-	//z-index: z-index( 'root', '.global-notices' );
-	z-index: 100;
+	z-index: z-index( 'root', '.global-notices' );
 	position: fixed;
 		top: auto;
 		right: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/5042
Fixes https://github.com/Automattic/jetpack/issues/5057

<img width="337" alt="zindexok" src="https://cloud.githubusercontent.com/assets/1041600/18183040/e784e6aa-7068-11e6-9e92-c64b0163557d.png">
