### PR TITLE
ClipboardButton: Import Button using ES6 modules syntax in ClipboardButton instead of require()

### DIFF
--- a/client/components/form/clipboard-button/index.jsx
+++ b/client/components/form/clipboard-button/index.jsx
@@ -11,7 +11,7 @@ var ReactDom = require( 'react-dom' ),
 /**
  * Internal dependencies
  */
-var Button = require( 'components/button' );
+import Button from 'components/button';
 
 module.exports = React.createClass( {
 	displayName: 'ClipboardButton',
@@ -49,7 +49,6 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var classes = classNames( 'dops-clipboard-button', this.props.className );
-
 		return (
 			<Button
 				ref="button"


### PR DESCRIPTION
Fixes Automattic/jetpack#5094

After upgrading to Babel 6, mixing usages of `export default` and `require()` does not work in the same way as before.

#### Testing instructions

1. On Jetpack, with this module `npm link`ed to this branch, try to expand the **Post By Email** card under the **Writing** tab.
1. Expect to see the card expand normally.