### PR TITLE
Accept new versions of React as peer dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .sass-cache
+*.iml

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "merge-stream": "^1.0.0",
     "node-sass": "^3.3.2",
     "raw-loader": "^0.5.1",
+    "react": "^0.14.8",
+    "react-dom": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "react-redux": "^4.4.1",
     "sass-loader": "^2.0.1",
@@ -41,15 +43,13 @@
     "creditcards": "^2.0.0",
     "debug": "^2.2.0",
     "focus-trap": "gravityrail/focus-trap",
-    "formsy-react": "^0.17.0",
+    "formsy-react": "^0.18.1",
     "html-loader": "0.4.0",
     "inherits": "^2.0.1",
     "jquery": "^2.1.4",
     "lodash": "4.5.0",
     "page": "^1.6.3",
     "payment": "0.0.9",
-    "react": "^0.14.8",
-    "react-dom": "0.14.3",
     "react-pure-render": "1.0.2",
     "redux": "3.0.4",
     "store": "^1.3.17",
@@ -70,5 +70,9 @@
   "browserify-shim": {
     "underscore": "global:_",
     "react": "global:React"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Currently, `dops-components` is quite strict in the versions of React defined in its dependencies.
This can cause some issues for projects using React 15.x.x and dops-components as they might be bundling 2 versions of react (with webpack for instance).

This PR makes `react` and `react-dom` peer and dev dependencies with broader version support for peer dependencies.

It also explicitly upgrades `react-formsy` to `0.18.1` (even though this version matched `^0.17.0`) because it officially supports both versions of react: https://github.com/christianalfoni/formsy-react/blob/v0.18.1/package.json#L45

