### PR TITLE
Render borderless buttons transparent in background-color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .sass-cache
 *.iml
+.idea

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -151,6 +151,7 @@
 }
 
 .dops-button.is-borderless {
+	background-color: transparent;
 	border: none;
 	color: darken( $gray, 10% );
 	padding-left: 0;


### PR DESCRIPTION
Borderless components, such as those with icons, can be more useable if the default background-color is set to transparent.

Cheers!
