### PR TITLE
Popover: add else branch in tip-arrow mixing

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -37,6 +37,10 @@
 	}
 
 	@mixin popover__arrow( $side ) {
+		$opposite-side: "";
+		$cross-side: "";
+		$cross-opposite-side: "";
+
 		@if $side == "top" {
 			$opposite-side: "bottom";
 			$cross-side: "left";
@@ -53,10 +57,6 @@
 			$opposite-side: "left";
 			$cross-side: "top";
 			$cross-opposite-side: "bottom";
-		} @else {
-			$opposite-side: "";
-			$cross-side: "";
-			$cross-opposite-side: "";
 		}
 
 		&.is-#{$side} .dops-popover__arrow,

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -53,6 +53,10 @@
 			$opposite-side: "left";
 			$cross-side: "top";
 			$cross-opposite-side: "bottom";
+		} @else {
+			$opposite-side: "";
+			$cross-side: "";
+			$cross-opposite-side: "";
 		}
 
 		&.is-#{$side} .dops-popover__arrow,


### PR DESCRIPTION
This is so there's a fallback case if side isn't defined.
This helps the building process when it's used in Jetpack with node-sass 3.7.2 and node 6.2.1

Companion to https://github.com/Automattic/jetpack/pull/4295

cc @zinigor 