### PR TITLE
Move `babel-plugin-add-module-exports` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
     "react": "global:React"
   },
   "peerDependencies": {
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "babel-runtime": "^6.6.1",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   }


### PR DESCRIPTION
As of #64, this package needs to be installed in every repo that transpiles `dops-components` or it fails when that repo (such as Delphin) tries to build anything from `dops-components`:

```bash
ERROR in ./~/@automattic/dops-components/client/components/gridicon/index.jsx
Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in "/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/@automattic/dops-components/.babelrc" at
 0, attempted to resolve relative to "/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/@automattic/dops-components"
    at /Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:176:17
    at Array.map (native)
    at Function.normalisePlugins (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:154:20)
    at OptionManager.mergeOptions (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:228:36)
    at OptionManager.init (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/options/option-manager.js:373:12)
    at File.initOptions (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/index.js:221:65)
    at new File (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/file/index.js:141:24)
    at Pipeline.transform (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-loader/index.js:38:20)
    at Object.module.exports (/Users/drewblaisdell/Desktop/a8c/delphin/node_modules/babel-loader/index.js:131:12)
 @ ./app/components/ui/checkout/index.js 108:15-80
 @ ./app/components/containers/checkout.js
 @ ./app/sections/checkout.js
 @ ./app/sections/index.js
 @ ./client/index.js
 @ multi app
```

If we move it to `dependencies` from `devDependencies`, we ensure that it will be installed. This should probably happen for other `devDependencies`, but the versions don't line up between this and Calypso and lining those up will require further testing.

**Testing**
- In Delphin on `master`, update `node_modules/@automattic/dops-components/package.json` in Delphin with the change from this commit and assert that it runs successfully when running `npm start`.