### PR TITLE
Notices: removes double icon displayed

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -15,17 +15,6 @@
 
 	@include breakpoint( ">660px" ) {
 		font-size: inherit;
-
-		&::before {
-			@include dashicons;
-			content: '\f534';
-			position: absolute;
-				top: 23px;
-				left: 20px;
-			margin: -12px 0px 0 -8px;
-			font-size: 24px;
-			line-height: 1;
-		}
 	}
 
 	.dops-notice__dismiss {


### PR DESCRIPTION
cc @MichaelArestad @jeffgolenski 

This fixes this issue https://github.com/Automattic/jetpack/issues/5325 but would like to know if this won't break anything else.