### PR TITLE
Use lodash's assign() to avoid errors in IE which doesn't support Object.assign

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
 import classNames from 'classnames';
 import clickOutside from 'click-outside';
 import uid from 'component-uid';
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
@@ -288,7 +289,7 @@ class Popover extends Component {
 			this.debug( 'suggested position: %o', suggestedPosition );
 		}
 
-		const reposition = Object.assign(
+		const reposition = assign(
 			{},
 			constrainLeft(
 				offset( suggestedPosition, domContainer, domContext ),

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -4,7 +4,8 @@
 var debug = require( 'debug' )( 'calypso:store-transactions' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	Readable = require( 'stream' ).Readable,
-	inherits = require( 'inherits' );
+	inherits = require( 'inherits' ),
+	assign = require( 'lodash/assign' );
 
 /**
  * Internal dependencies
@@ -76,7 +77,7 @@ TransactionFlow.prototype._pushStep = function( options ) {
 		timestamp: Date.now()
 	};
 
-	this.push( Object.assign( defaults, options ) );
+	this.push( assign( defaults, options ) );
 }
 
 TransactionFlow.prototype._paymentHandlers = {


### PR DESCRIPTION
Introduced in response to https://github.com/Automattic/jetpack/issues/5724

Regardless of whether it fixes that issue or not, this PR should be merged anyway since IE doesn't support Object.assign and will throw JS errors. By using lodash's `assign` we can avoid these issues.