### PR TITLE
Fixes section-header component when strings get too long

### DIFF
--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -26,16 +26,14 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			label: '',
-			cardBadge: '',
-			pro: ''
+			cardBadge: ''
 		};
 	},
 
 	render() {
 		const classes = classNames(
 			this.props.className,
-			'dops-section-header',
-			'has-card-badge': this.props.cardBadge !== ''
+			'dops-section-header'
 		);
 
 		const maybeShowCardBadge = this.props.cardBadge !== ''
@@ -43,7 +41,7 @@ export default React.createClass( {
 			: '';
 
 		return (
-			<Card compact className={ classes }>
+			<Card compact className={ classNames( classes, { 'has-card-badge': this.props.cardBadge !== '' } ) }>
 				<div className="dops-section-header__label">
 					<span className="dops-section-header__label-text">{ this.props.label }</span>
 					{ maybeShowCardBadge }

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -26,14 +26,16 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			label: '',
-			cardBadge: ''
+			cardBadge: '',
+			pro: ''
 		};
 	},
 
 	render() {
 		const classes = classNames(
 			this.props.className,
-			'dops-section-header'
+			'dops-section-header',
+			'has-card-badge': this.props.cardBadge !== ''
 		);
 
 		const maybeShowCardBadge = this.props.cardBadge !== ''
@@ -43,7 +45,7 @@ export default React.createClass( {
 		return (
 			<Card compact className={ classes }>
 				<div className="dops-section-header__label">
-					{ this.props.label }
+					<span className="dops-section-header__label-text">{ this.props.label }</span>
 					{ maybeShowCardBadge }
 				</div>
 				<div className="dops-section-header__actions">

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -20,6 +20,7 @@
 	display: flex;
 		align-items: center;
 	flex-grow: 1;
+	min-width: 0; // weird fix for overflowing items
 	line-height: rem( 28px );
 	position: relative;
 	color: $gray;
@@ -35,6 +36,7 @@
 	margin-right: rem( 8px );
 	white-space: nowrap;
 	overflow: hidden;
+	min-width: 0; // weird fix for overflowing items
 
 	&:before {
 		@include long-content-fade( $color : $white );

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -36,10 +36,15 @@
 	margin-right: rem( 8px );
 	white-space: nowrap;
 	overflow: hidden;
+	width: 100%;
+	padding-right: rem( 8px );
 	min-width: 0; // weird fix for overflowing items
 
 	&:before {
-		@include long-content-fade( $color : $white );
+		@include long-content-fade( $size: 8px, $color : $white );
+	}
+	.has-card-badge & {
+		width: auto;
 	}
 }
 

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -5,6 +5,8 @@
 
 .dops-section-header.dops-card {
 	display: flex;
+	flex-wrap: wrap;
+	max-width: 100%;
 	padding-top: rem( 11px );
 	padding-bottom: rem( 11px );
 	position: relative;
@@ -23,17 +25,20 @@
 	color: $gray;
 	font-size: rem( 14px );
 
-	&:before {
-		@include long-content-fade( $color : $white );
-	}
-
 	.dops-count {
 		margin-left: rem( 8px );
 	}
 }
 
-.dops-section-header__card-badge {
-	margin-left: rem( 8px );
+.dops-section-header__label-text {
+	position: relative;
+	margin-right: rem( 8px );
+	white-space: nowrap;
+	overflow: hidden;
+
+	&:before {
+		@include long-content-fade( $color : $white );
+	}
 }
 
 .dops-section-header__actions {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/5565

To test:

* switch to `fix/5565` branch on Jetpack
* go to dashboard
* change a dashboard title to be really long or switch to Russian
* resize the window a bunch


#### Before
<img width="753" alt="screen shot 2017-01-02 at 4 45 45 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597646/00da1a00-d10b-11e6-8c27-9d952ddaecfd.png">
<img width="410" alt="screen shot 2017-01-02 at 4 46 07 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597647/01169c8c-d10b-11e6-890e-8f8bb7602b51.png">


#### After
<img width="597" alt="screen shot 2017-01-02 at 4 40 46 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597599/6037f90a-d10a-11e6-960a-7bf75df76175.png">
<img width="427" alt="screen shot 2017-01-02 at 4 41 02 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597601/60943620-d10a-11e6-92bf-9875b338ae83.png">
<img width="785" alt="screen shot 2017-01-02 at 4 41 32 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597600/60936f6a-d10a-11e6-8d2e-e105cf28547d.png">
