### PR TITLE
Add a class .dops-form-toggle to span wrapping all FormToggle contents

### DIFF
--- a/client/components/form/form-toggle/index.jsx
+++ b/client/components/form/form-toggle/index.jsx
@@ -48,7 +48,7 @@ module.exports = React.createClass( {
 			} );
 
 		return (
-			<span>
+			<span className="dops-form-toggle">
 				<input
 					className={ classNames( this.props.className, toggleClasses ) }
 					type="checkbox"


### PR DESCRIPTION
This will add a class to the FormToggle wrapper that will allow to target a fieldset that is placed after it. For example:
```scss
.dops-form-toggle {
	& + .jp-form-fieldset,
	& + .jp-form-setting-explanation {
		margin-left: rem( 34px );
	}
}
```