### PR TITLE
Fix issue where body jumps when modal is open

### DIFF
--- a/client/components/modal/index.jsx
+++ b/client/components/modal/index.jsx
@@ -46,12 +46,12 @@ let Modal = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		jQuery( 'body' ).addClass( 'dops-modal-showing' );
+		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.jetpack', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
 			focusTrap.activate(this.getDOMNode(), {
 				// onDeactivate: this.maybeClose,
-				initialFocus: this.props.initialFocus,
+				initialFocus: this.props.initialFocus
 			});
 		} catch( e ) {
 			//noop
@@ -59,7 +59,7 @@ let Modal = React.createClass( {
 	},
 
 	componentWillUnmount: function() {
-		jQuery( 'body' ).removeClass( 'dops-modal-showing' );
+		jQuery( 'body' ).removeClass( 'dops-modal-showing' ).off( 'touchmove.jetpack', false );
 		jQuery( document ).unbind( 'keyup', this.handleEscapeKey );
 		try {
 			focusTrap.deactivate();

--- a/client/components/modal/style.scss
+++ b/client/components/modal/style.scss
@@ -4,7 +4,6 @@
 /* This hack is used to prevent the body from scrolling when the modal is showing */
 body.dops-modal-showing {
 	overflow: hidden;
-    position: fixed;
 }
 
 .dops-modal-wrapper {


### PR DESCRIPTION
This solves an issue noticed in Jetpack admin: when the body was opened, the page jumped towards left. This is due to the `position:fixed` that was applied.

![jump](https://cloud.githubusercontent.com/assets/1041600/22306966/0a47e956-e320-11e6-801d-b1eb30c6fb3f.gif)

This PR offers a solution to this and preserves the desired behavior in iOS devices of not scrolling the body behind the modal when it's open.

To test, use this Jetpack branch https://github.com/Automattic/jetpack/pull/6159 and
- go to your local clone of `dops-component` repo, switch to this branch `fix/body-jump-modal-open`
- do `npm link`
- go to `jetpack`, switch to this branch `add/general-settings`
- do `npm link @automattic/dops-component`
- do `yarn build`