### PR TITLE
FormToggle, SelectDropdown: if it's disabled, disable click events.

### DIFF
--- a/client/components/form/form-toggle/index.jsx
+++ b/client/components/form/form-toggle/index.jsx
@@ -39,6 +39,12 @@ module.exports = React.createClass( {
 		}
 	},
 
+	_onChange: function() {
+		if ( ! this.props.disabled ) {
+			this.props.onChange();
+		}
+	},
+
 	render: function() {
 		var id = this.props.id || 'toggle-' + idNum++,
 			toggleClasses = classNames( {
@@ -60,7 +66,7 @@ module.exports = React.createClass( {
 					<span className="form-toggle__switch"
 						disabled={ this.props.disabled }
 						id={ id }
-						onClick={ this.props.onChange }
+						onClick={ this._onChange }
 						onKeyDown={ this._onKeyDown }
 						role="checkbox"
 						aria-checked={ this.props.checked }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -40,6 +40,7 @@ class SelectDropdown extends Component {
 		this.navigateItem = this.navigateItem.bind( this );
 		this.toggleDropdown = this.toggleDropdown.bind( this );
 		this.handleOutsideClick = this.handleOutsideClick.bind( this );
+		this._onClick = this._onClick.bind( this );
 
 		// state
 		let initialState = { isOpen: false };
@@ -175,7 +176,8 @@ class SelectDropdown extends Component {
 		const dropdownClasses = {
 			'dops-select-dropdown': true,
 			'is-compact': this.props.compact,
-			'is-open': this.state.isOpen
+			'is-open': this.state.isOpen,
+			'is-disabled': this.props.disabled
 		};
 
 		if ( this.props.className ) {
@@ -203,7 +205,7 @@ class SelectDropdown extends Component {
 					aria-owns={ 'select-submenu-' + this.state.instanceId }
 					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
-					onClick={ this.toggleDropdown }
+					onClick={ this._onClick }
 				>
 					<div
 						id={ 'select-dropdown-' + this.state.instanceId }
@@ -230,6 +232,12 @@ class SelectDropdown extends Component {
 				</div>
 			</div>
 		);
+	}
+
+	_onClick() {
+		if ( ! this.props.disabled ) {
+			this.toggleDropdown();
+		}
 	}
 
 	toggleDropdown() {
@@ -368,6 +376,7 @@ SelectDropdown.defaultProps = {
 	options: [],
 	onSelect: noop,
 	onToggle: noop,
+	disabled: false,
 	style: {}
 };
 
@@ -381,6 +390,7 @@ SelectDropdown.propTypes = {
 	onToggle: PropTypes.func,
 	focusSibling: PropTypes.func,
 	tabIndex: PropTypes.number,
+	disabled: PropTypes.bool,
 	options: PropTypes.arrayOf(
 		PropTypes.shape( {
 			value: PropTypes.string.isRequired,

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -14,6 +14,13 @@
 	&.is-compact {
 		height: 28px;
 	}
+
+	&.is-disabled .dops-select-dropdown__header {
+		background: $gray-light;
+		border-color: lighten( $gray, 30% );
+		color: lighten( $gray, 10% );
+		-webkit-text-fill-color: lighten( $gray, 10% );
+	}
 }
 
 .dops-select-dropdown__container {


### PR DESCRIPTION
### FormToggle 
For this component this PR seeks to resolve an issue where the `disabled` property works for keys but not for click events.
Before this PR, if you pass `disabled` as property, the toggle is visually "disabled" but in reality you can still click the element.

### SelectDropdown
In this component the disabled state didn't existed. It has now been implemented and it looks like a disabled TextInput.
<img width="176" alt="captura de pantalla 2017-01-27 a las 21 48 06" src="https://cloud.githubusercontent.com/assets/1041600/22392637/5032d2d0-e4da-11e6-9a1b-0db5642877cd.png">
