### PR TITLE
Modal: replace getDOMNode() call to avoid issuing a warning in JS console.

### DIFF
--- a/client/components/modal/index.jsx
+++ b/client/components/modal/index.jsx
@@ -1,4 +1,5 @@
 var React = require( 'react' ),
+	ReactDOM = require( 'react-dom' ),
 	classNames = require( 'classnames' ),
 	assign = require( 'lodash/assign' );
 
@@ -48,7 +49,7 @@ let Modal = React.createClass( {
 		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.dopsmodal', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
-			focusTrap.activate(this.getDOMNode(), {
+			focusTrap.activate( ReactDOM.findDOMNode( this ), {
 				// onDeactivate: this.maybeClose,
 				initialFocus: this.props.initialFocus
 			});


### PR DESCRIPTION
Fixes #85 

This PR solves a warning regarding `this.getDOMNode()` that was deprecated as of React 0.14 and replaced by `ReactDOM.findDOMNode(this)`.

See https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#new-deprecations-introduced-with-a-warning

Reported
https://github.com/Automattic/jetpack/pull/6287#issuecomment-277384301