### PR TITLE
Ported over changes to the search component from wp-calypso.

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -1,6 +1,7 @@
 @import '../../scss/calypso-colors';
 @import '../../scss/z-index';
 @import '../../scss/mixin_breakpoint';
+@import '../../scss/mixin_long-content-fade';
 @import '../../scss/rem';
 @import '../../scss/z-index';
 
@@ -8,120 +9,90 @@
  * @component Search
  */
 .dops-search {
+	display: flex;
+	flex: 1 1 auto;
 	margin-bottom: 24px;
 	width: 60px;
 	height: 51px;
 	position: relative;
+	align-items: center;
 	// places search above filters
 	z-index: z-index( 'root', '.dops-search' );
+	transition: all 0.15s ease-in-out;
 
-	@include breakpoint( "<660px" ) {
-		width: 50px;
+	.dops-search__icon-navigation {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: center;
+		background-color: $white;
+		border-radius: inherit;
+		height: 100%;
 	}
 
-	.dops-search-open__icon {
-		position: absolute;
-			top: 50%;
-		margin-top: -12px;
-		width: 60px;
-		z-index: z-index( '.dops-search', '.dops-search .dops-search-open__icon' );
+	.dops-search__open-icon,
+	.dops-search__close-icon {
+		flex: 0 0 auto;
+		width: 50px;
+		z-index: z-index( '.dops-search', '.dops-search .dops-search__open-icon' );
 		color: $blue-wordpress;
 		cursor: pointer;
 
-		.dops-accessible-focus &:focus {
+		.accessible-focus &:focus {
 			outline: dotted 1px $blue-wordpress;
 		}
-
-		@include breakpoint( "<660px" ) {
-			width: 50px;
-		}
-
 	}
 
-	.dops-search-open__icon:hover {
+	.dops-search__open-icon:hover {
 		color: darken( $gray, 30% );
 	}
 
-	.dops-search-close__icon {
-		position: absolute;
-			bottom: 0;
-			top: 50%;
-			right: 0;
-		margin-top: -12px;
-		width: 60px;
-		cursor: pointer;
-		z-index: z-index( '.dops-search', '.dops-search .dops-search-close__icon' );
+	.dops-search__close-icon {
 		color: darken( $gray, 30% );
-		display: none;
 		opacity: 0;
 		transition: opacity .2s ease-in;
+	}
 
-		.dops-accessible-focus &:focus {
-			outline: dotted 1px $blue-wordpress;
-		}
-
-		&::before {
-			position: absolute;
-				left: 0;
-				right: 0;
-				top: 50%;
-			margin-top: -8px;
-			font-size: 16px;
-			text-align: center;
-
-			@include breakpoint( "<660px" ) {
-				font-size: 14px;
-				margin-top: -7px;
-			}
-		}
-
-		@include breakpoint( "<660px" ) {
-			width: 50px;
-		}
+	.accessible-focus &.has-focus {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 }
 
 // Position collapsed search-button to the right
 // of the container element
-.dops-search.is-pinned {
+.dops-search.is-expanded-to-container {
 	margin-bottom: 0;
-	height: auto;
 	position: absolute;
-		bottom: 0;
-		top: 0;
-		right: 0;
-	// matching dropdown-selector
-	z-index: z-index( 'root', '.dops-search.is-pinned' );
+	display: flex;
+	height: 100%;
+	width: 50px;
+	top: 0;
+	right: 0;
 
-	.dops-search-open__icon {
-		right: 0;
+	.dops-search__input-fade {
+		position: relative;
+		flex: 1 1 auto;
+		display: flex;
 	}
 
 	.dops-search__input[type="search"] {
-		height: 100%;
+		flex: 1 1 auto;
+		display: flex;
 	}
 }
 
 .dops-search__input[type="search"] {
+	flex: 1 1 auto;
 	display: none;
-	position: absolute;
 	z-index: z-index( '.dops-search', '.dops-search__input' );
 	top: 0;
-	margin: 0;
-	padding: 0 50px 0 60px;
 	border: none;
+	border-radius: inherit;
+	height: 100%;
 	background: $white;
-	height: 51px;
 	appearance: none;
 	box-sizing: border-box;
+	padding: 0px;
 	-webkit-appearance: none;
-	box-shadow: none;
-
-	@include breakpoint( "<660px" ) {
-		opacity: 0;
-		left: 0;
-		padding-left: 50px;
-	}
 
 	&::-webkit-search-cancel-button {
 		-webkit-appearance: none;
@@ -135,51 +106,82 @@
 
 // When search input is opened
 .dops-search.is-open {
-	margin-right: 0 !important;
 	width: 100%;
 
-	.dops-search-open__icon {
+	.dops-search__open-icon {
 		color: darken( $gray, 30% );
-		left: 0;
 	}
 
-	.dops-search-close__icon {
+	.dops-search__close-icon {
 		display: inline-block;
 	}
 
 	.dops-search__input,
-	.dops-search-close__icon{
+	.dops-search__close-icon {
 		opacity: 1;
 	}
 
 	.dops-search__input {
 		display: block;
 	}
+
+	.dops-search__input-fade {
+		flex: 1 1 auto;
+		height: 100%;
+		position: relative;
+		font-size: 16px;
+		border-radius: inherit;
+		&::before {
+			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.dops-search', '.dops-search__input' ) + 2 );
+			border-radius: inherit;
+		}
+
+		&.ltr { /*rtl:ignore*/
+			&::before {
+				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.dops-search', '.dops-search__input' ) + 2 );
+				border-radius: inherit;
+			}
+		}
+	}
+}
+
+.dops-search__input-fade .dops-search__text-overlay {
+	color: transparent;
+	position: absolute;
+	pointer-events: none;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+	flex: 1 1 auto;
+	overflow: hidden;
+	font: inherit;
+	width: 100%;
+	height: 100%;
+	top: 0px;
+	left: 0px;
+	z-index: z-index( '.dops-search', '.dops-search__input' ) + 1;
 }
 
 .dops-search .dops-spinner {
 	display: none;
-	position: absolute;
-		top: 50%;
-		left: 30px;
-	transform: translate( -50%, -50% );
-
-	@include breakpoint( "<660px" ) {
-		left: 25px;
-	}
 }
 
-.dops-search.is-searching .dops-search-open__icon {
+.dops-search.is-searching .dops-search__open-icon {
 	display: none;
 }
 
 .dops-search.is-searching .dops-spinner {
-	display: block;
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	height: 100%;
 	z-index: z-index( '.dops-search', '.dops-search.is-searching .dops-spinner' );
+
+	.dops-spinner__image {
+		width: 50px;
+	}
 }
 
-@include breakpoint( "<660px" ) {
-	.animating.dops-search-opening .dops-search input {
+.animating.dops-search-opening .dops-search input {
 		opacity: 1;
-	}
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -77,6 +77,8 @@
 	.dops-search__input[type="search"] {
 		flex: 1 1 auto;
 		display: flex;
+		margin: 0;
+		box-shadow: none;
 	}
 }
 

--- a/client/mixins/url-search/README.md
+++ b/client/mixins/url-search/README.md
@@ -1,0 +1,67 @@
+url-search
+=============
+
+`url-search` ties a search component to an `s` querystring parameter, like `wordpress.com/posts?s=example`. This is useful to persist search result pages in the browser history[*](#history) and to make search result pages shareable.
+
+The `url-search` mixin takes the approach of only using state to track whether the search field should be open, and otherwise communicating the value of new searches by updating the URL, where the controller can read the value and use it to call whatever data is necessary, and then also pass it back into the Search component as initialValue.
+
+You would add this mixin to the component that _contains_ the search component, e.g., `/my-sites/posts/posts.jsx`.
+
+In your controller method, retrieve the search parameter from the URL and pass that into the component as a `search` prop. You also need to pass the context object itself into the component:
+
+```js
+var search = search = qs.parse( context.querystring ).s;
+
+ReactDom.render(
+	PostsComponent({
+		search: search,
+		context: context
+	}),
+	document.getElementById( 'primary' )
+);
+```
+
+Then in the component, apply the mixin:
+
+```js
+/**
+ * Internal dependencies
+ */
+
+var URLSearch = require( 'lib/mixins/url-search' );
+
+module.exports = React.createClass({
+
+	displayName: 'Posts',
+
+	mixins: [ URLSearch ],
+```
+
+Then within your render method, apply the following properties to the `Search` component; `onSearch`, `initialValue`, and `ref` (with a value of "url-search").
+
+```jsx
+	render: function() {
+
+		return (
+			<Search onSearch={ this.doSearch } initialValue={ this.props.search } delaySearch={ true } ref="url-search"/>
+		);
+```
+
+_If_ your search component should only be displayed dynamically, you can use `this.getSearchOpen()` to determine whether the search should be open or closed, like so:
+
+```jsx
+	render: function() {
+
+		var containerClass = classNames( {
+			'search-open': this.getSearchOpen()
+		} );
+
+		return (
+			<div class={ containerClass } >
+				<Search onSearch={ this.doSearch } initialValue={ this.props.search } delaySearch={ true } ref="url-search"/>
+			</div>
+		);
+```
+
+## History
+`url-search` adds the first search result page to the browser history, and then uses push-state to update the page on subsequent searches. So only the most-recent search is persisted in the browser's history.

--- a/client/mixins/url-search/build-url.js
+++ b/client/mixins/url-search/build-url.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+var url = require( 'url' ),
+	pick = require( 'lodash/pick' );
+
+/**
+ * Given a URL or path and search terms, returns a path including the search
+ * query parameter and preserving existing parameters.
+ *
+ * @param  {string} uri    URL or path to modify
+ * @param  {string} search Search terms
+ * @return {string}        Path including search terms
+ */
+module.exports = function( uri, search ) {
+	var parsedUrl = url.parse( uri, true );
+
+	if ( search ) {
+		parsedUrl.query.s = search;
+	} else {
+		delete parsedUrl.query.s;
+	}
+
+	parsedUrl = pick( parsedUrl, 'pathname', 'hash', 'query' );
+	return url.format( parsedUrl ).replace( /\%20/g, '+' );
+};

--- a/client/mixins/url-search/index.js
+++ b/client/mixins/url-search/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+var debug = require( 'debug' )( 'calypso:url-search' ),
+	page = require( 'page' );
+
+/**
+ * Internal dependencies
+ */
+var buildUrl = require( './build-url' );
+
+module.exports = {
+
+	getInitialState: function() {
+		return {
+			searchOpen: false
+		};
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( ! nextProps.search ) {
+			this.setState( {
+				searchOpen: false
+			} );
+		}
+	},
+
+	doSearch: function( keywords ) {
+		var searchURL;
+
+		this.setState( {
+			searchOpen: ( false !== keywords )
+		} );
+
+		if ( this.onSearch ) {
+			this.onSearch( keywords );
+			return;
+		}
+
+		if ( this.buildUrl && 'function' === typeof this.buildUrl ) {
+			searchURL = this.buildUrl( window.location.href, keywords );
+		} else {
+			searchURL = buildUrl( window.location.href, keywords );
+		}
+
+		debug( 'search posts for:', keywords );
+		if ( this.props.search && keywords ) {
+			debug( 'replacing URL: ' + searchURL );
+			page.replace( searchURL );
+		} else {
+			debug( 'setting URL: ' + searchURL );
+			page( searchURL );
+		}
+	},
+
+	getSearchOpen: function() {
+		return ( this.state.searchOpen !== false || this.props.search );
+	}
+
+};

--- a/client/scss/z-index.scss
+++ b/client/scss/z-index.scss
@@ -166,8 +166,8 @@ $z-layers: (
 	'.dops-search': (
 		'.dops-search__input': 10,
 		'.dops-search.is-searching .dops-spinner': 20,
-		'.dops-search .dops-search-open__icon': 20,
-		'.dops-search .dops-search-close__icon': 20
+		'.dops-search .dops-search__open-icon': 20,
+		'.dops-search .dops-search__close-icon': 20
 	),
 	'.profile-gravatar__edit-label-wrap': (
 		'.profile-gravatar__edit-label-wrap:after': 0,


### PR DESCRIPTION
This aims to fix https://github.com/Automattic/jetpack/issues/6414 by adding changes from wp-calypso. The new component should work out of the box with the same usage interface, but currently it has some styling problems. @MichaelArestad can you please take a look at this?

This is what search looks now when it's closed:
![search-closed](https://cloud.githubusercontent.com/assets/374293/22995064/b41b27a4-f3e2-11e6-94cd-5b64dde74f8a.png)

And that's what it looks like when it's open:
![search-open](https://cloud.githubusercontent.com/assets/374293/22995071/ba805420-f3e2-11e6-970a-39f064a2d4c1.png)
