### PR TITLE
Update form-toggle to latest Calypso

### DIFF
--- a/client/components/form/form-toggle/index.jsx
+++ b/client/components/form/form-toggle/index.jsx
@@ -1,80 +1,108 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
-
-var idNum = 0;
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 require( './style.scss' );
 
-module.exports = React.createClass( {
+export default class FormToggle extends Component {
+	static propTypes = {
+		onChange: PropTypes.func,
+		onKeyDown: PropTypes.func,
+		checked: PropTypes.bool,
+		disabled: PropTypes.bool,
+		id: PropTypes.string,
+		className: PropTypes.string,
+		toggling: PropTypes.bool,
+		'aria-label': PropTypes.string,
+		children: PropTypes.node
+	};
 
-	displayName: 'FormToggle',
+	static defaultProps = {
+		checked: false,
+		disabled: false,
+		onKeyDown: () => {},
+		onChange: () => {}
+	};
 
-	propTypes: {
-		onChange: React.PropTypes.func,
-		checked: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		className: React.PropTypes.string,
-		compact: React.PropTypes.bool,
-		id: React.PropTypes.string
-	},
+	static idNum = 0;
 
-	getDefaultProps: function() {
-		return {
-			checked: false,
-			disabled: false
-		};
-	},
-	_onKeyDown: function( event ) {
-		if ( ! this.props.disabled ) {
-			if ( event.key === 'Enter' || event.key === ' ' ) {
-				event.preventDefault();
-				this.props.onChange();
-			}
+	constructor() {
+		super( ...arguments );
+
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onClick = this.onClick.bind( this );
+		this.onLabelClick = this.onLabelClick.bind( this );
+	}
+
+	componentWillMount() {
+		this.id = this.constructor.idNum++;
+	}
+
+	onKeyDown( event ) {
+		if ( this.props.disabled ) {
+			return;
 		}
-		if ( this.props.onKeyDown ) {
-			this.props.onKeyDown( event );
-		}
-	},
 
-	_onChange: function() {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.props.onChange();
+		}
+
+		this.props.onKeyDown( event );
+	}
+
+	onClick() {
 		if ( ! this.props.disabled ) {
 			this.props.onChange();
 		}
-	},
+	}
 
-	render: function() {
-		var id = this.props.id || 'toggle-' + idNum++,
-			toggleClasses = classNames( {
-				'form-toggle': true,
-				'is-toggling': this.props.toggling,
-				'is-compact': this.props.compact
-			} );
+	onLabelClick( event ) {
+		if ( this.props.disabled ) {
+			return;
+		}
+
+		const nodeName = event.target.nodeName.toLowerCase();
+		if ( nodeName !== 'a' && nodeName !== 'input' && nodeName !== 'select' ) {
+			event.preventDefault();
+			this.props.onChange();
+		}
+	}
+
+	render() {
+		const id = this.props.id || 'toggle-' + this.id;
+		const toggleClasses = classNames( 'form-toggle', this.props.className, {
+			'is-toggling': this.props.toggling
+		} );
 
 		return (
 			<span>
 				<input
-					className={ classNames( this.props.className, toggleClasses ) }
+					className={ toggleClasses }
 					type="checkbox"
 					checked={ this.props.checked }
 					readOnly={ true }
 					disabled={ this.props.disabled }
-					/>
+				/>
 				<label className="form-toggle__label" htmlFor={ id } >
-					<span className="form-toggle__switch"
+					<span
+						className="form-toggle__switch"
 						disabled={ this.props.disabled }
 						id={ id }
-						onClick={ this._onChange }
-						onKeyDown={ this._onKeyDown }
+						onClick={ this.onClick }
+						onKeyDown={ this.onKeyDown }
 						role="checkbox"
 						aria-checked={ this.props.checked }
+						aria-label={ this.props[ 'aria-label' ] }
 						tabIndex={ this.props.disabled ? -1 : 0 }
-						></span>
-					{ this.props.children }
+					></span>
+					<span className="form-toggle__label-content" onClick={ this.onLabelClick }>
+						{ this.props.children }
+					</span>
 				</label>
 			</span>
 		);
 	}
-} );
+}

--- a/client/components/form/form-toggle/style.scss
+++ b/client/components/form/form-toggle/style.scss
@@ -15,11 +15,10 @@
 	padding: 2px;
 	width: 40px;
 	height: 24px;
-	background: lighten( $gray, 10% );
 	vertical-align: middle;
 	outline: 0;
 	cursor: pointer;
-	transition: all .4s ease, box-shadow 0;
+	transition: all .4s ease, box-shadow 0s;
 
 	&:before,
 	&:after {
@@ -38,23 +37,26 @@
 	&:before {
 		display: none;
 	}
-	&:hover {
-		background: lighten( $gray, 20% );
-	}
-	.dops-accessible-focus &:focus,
-	&:focus {
+	.accessible-focus &:focus{
 		box-shadow: 0 0 0 2px $blue-medium;
 	}
 }
 
 .form-toggle__label {
 	cursor: pointer;
-	width: auto;
-	float: none;
+
+	.is-disabled & {
+		cursor: default;
+	}
+
+	.form-toggle__label-content {
+		flex: 0 1 100%;
+		margin-left: 12px;
+	}
 }
 
 .form-toggle {
-	.dops-accessible-focus &:focus {
+	.accessible-focus &:focus {
 		+ .form-toggle__label .form-toggle__switch {
 			box-shadow: 0 0 0 2px $blue-medium;
 		}
@@ -62,6 +64,17 @@
 			box-shadow: 0 0 0 2px $blue-light;
 		}
 	}
+
+	& + .form-toggle__label .form-toggle__switch {
+		background: lighten( $gray, 10% );
+	}
+
+	&:not( :disabled ) {
+		+ .form-toggle__label .form-toggle__switch:hover {
+			background: lighten( $gray, 20% );
+		}
+	}
+
 	&:checked{
 		+ .form-toggle__label .form-toggle__switch {
 			background: $blue-medium;
@@ -71,15 +84,17 @@
 			}
 		}
 	}
-	&:checked:hover {
-		+ .form-toggle__label .form-toggle__switch {
+
+	&:checked:not( :disabled ) {
+		+ .form-toggle__label .form-toggle__switch:hover {
 			background: $blue-light;
 		}
 	}
-	&:disabled,
-	&:disabled:hover {
-		+ .form-toggle__label .form-toggle__switch {
-			background: lighten( $gray, 30% );
+
+	&:disabled {
+		+ label.form-toggle__label span.form-toggle__switch {
+			opacity: 0.25;
+			cursor: default;
 		}
 	}
 }

--- a/client/components/form/form-toggle/style.scss
+++ b/client/components/form/form-toggle/style.scss
@@ -37,7 +37,7 @@
 	&:before {
 		display: none;
 	}
-	.accessible-focus &:focus{
+	.dops-accessible-focus &:focus{
 		box-shadow: 0 0 0 2px $blue-medium;
 	}
 }
@@ -56,7 +56,7 @@
 }
 
 .form-toggle {
-	.accessible-focus &:focus {
+	.dops-accessible-focus &:focus {
 		+ .form-toggle__label .form-toggle__switch {
 			box-shadow: 0 0 0 2px $blue-medium;
 		}

--- a/client/components/form/form-toggle/test/index.jsx
+++ b/client/components/form/form-toggle/test/index.jsx
@@ -33,14 +33,14 @@ describe( 'FormToggle', function() {
 
 	describe( 'rendering', function() {
 		it( 'should have form-toggle class', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle /> ),
+			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle /> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );
 
 			assert( 0 < toggleInput.length, 'a form toggle was rendered' );
 		} );
 
 		it( 'should not have is-compact class', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle /> ),
+			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle /> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'is-compact' );
 
 			assert( 0 === toggleInput.length, 'no form toggle with is-compact class' );
@@ -49,7 +49,7 @@ describe( 'FormToggle', function() {
 		it( 'should be checked when checked is true', function() {
 			[ true, false ].forEach( function( bool ) {
 				var toggle = TestUtils.renderIntoDocument(
-						<FormToggle
+						<CompactFormToggle
 						checked={ bool }
 						onChange={ function() {
 							return;
@@ -63,7 +63,7 @@ describe( 'FormToggle', function() {
 		} );
 
 		it( 'should not be disabled when disabled is false', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ false } disabled={ false }/> ),
+			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle checked={ false } disabled={ false }/> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );
 
 			assert( 0 < toggleInput.length, 'a form toggle was rendered' );
@@ -71,7 +71,7 @@ describe( 'FormToggle', function() {
 		} );
 
 		it( 'should be disabled when disabled is true', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ false } disabled={ true }/> ),
+			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle checked={ false } disabled={ true }/> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );
 
 			assert( 0 < toggleInput.length, 'a form toggle was rendered' );
@@ -79,7 +79,7 @@ describe( 'FormToggle', function() {
 		} );
 
 		it( 'should have a label whose htmlFor matches the checkbox id', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ false } /> ),
+			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle checked={ false } /> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle__switch' ),
 				toggleLabel = TestUtils.scryRenderedDOMComponentsWithTag( toggle, 'label' );
 
@@ -89,9 +89,9 @@ describe( 'FormToggle', function() {
 		it( 'should create unique ids for each toggle', function() {
 			var toggles = TestUtils.renderIntoDocument(
 					<div>
-						<FormToggle checked={ false } />
-						<FormToggle checked={ false } />
-						<FormToggle checked={ false } />
+						<CompactFormToggle checked={ false } />
+						<CompactFormToggle checked={ false } />
+						<CompactFormToggle checked={ false } />
 					</div>
 				),
 				toggleInputs = TestUtils.scryRenderedDOMComponentsWithClass( toggles, 'form-toggle' ),


### PR DESCRIPTION
The only difference from Calypso we're doing is extending `FormToggle` off of `Component` rather than `PureComponent`, because `PureComponent` is only available in React versions > 15.something and I didn't want to go down that rabbit hole.  

To Test: 
- Link to https://github.com/Automattic/jetpack/pull/6425
- Make sure toggles look/work as expected