### PR TITLE
FormToggle: updated flex stuff so that the label now correctly indents

### DIFF
--- a/client/components/form/form-toggle/style.scss
+++ b/client/components/form/form-toggle/style.scss
@@ -8,6 +8,7 @@
 }
 
 .form-toggle__switch {
+	flex: none;
 	position: relative;
 	display: inline-block;
 	border-radius: 12px;
@@ -43,6 +44,7 @@
 }
 
 .form-toggle__label {
+	display: flex;
 	cursor: pointer;
 
 	.is-disabled & {


### PR DESCRIPTION
You can test on: https://github.com/Automattic/jetpack/pull/6516

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23381690/9c62de2c-fcfc-11e6-85c4-21ef076b8256.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23381470/d4fb1f3e-fcfb-11e6-9ec6-3f7496714ac5.png)
