### PR TITLE
Set foldable card arrow dropdown button to type=button

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -93,7 +93,7 @@ var FoldableCard = React.createClass( {
 		if ( this.props.children ) {
 			let iconSize = 24;
 			return (
-				<button disabled={ this.props.disabled } className="dops-foldable-card__action dops-foldable-card__expand" onClick={ clickAction }>
+				<button type="button" disabled={ this.props.disabled } className="dops-foldable-card__action dops-foldable-card__expand" onClick={ clickAction }>
 					<span className="screen-reader-text">More</span>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>


### PR DESCRIPTION
This is to ensure that if there's a foldable card within a form, it will not submit on expand.  I don't think there's any situation where that would be expected behavior.  