### PR TITLE
Settings UI: make section header text dark instead of gray to match Calypso

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -23,7 +23,7 @@
 	min-width: 0; // weird fix for overflowing items
 	line-height: rem( 28px );
 	position: relative;
-	color: $gray;
+	color: $gray-dark;
 	font-size: rem( 14px );
 
 	.dops-count {


### PR DESCRIPTION
Before

<img width="736" alt="captura de pantalla 2017-03-09 a las 17 11 13" src="https://cloud.githubusercontent.com/assets/1041600/23768639/760303aa-04eb-11e7-9249-e1aae9924a99.png">

After

<img width="737" alt="captura de pantalla 2017-03-09 a las 17 10 51" src="https://cloud.githubusercontent.com/assets/1041600/23768637/74ec8162-04eb-11e7-9068-ace8ba0bfe08.png">

Comparison with Calypso

<img width="674" alt="captura de pantalla 2017-03-09 a las 17 13 17" src="https://cloud.githubusercontent.com/assets/1041600/23768724/b3fcc9d4-04eb-11e7-8232-82a0a23e2487.png">

