### PR TITLE
New tracks function `recordJetpackClick`

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -2,6 +2,7 @@
 * External dependencies
 */
 import React from 'react';
+import noop from 'lodash/noop';
 
 /**
 * Internal dependencies
@@ -24,6 +25,7 @@ export default React.createClass( {
 		rootClassName: React.PropTypes.string,
 		gaEventCategory: React.PropTypes.string,
 		popoverName: React.PropTypes.string,
+		onClick: React.PropTypes.func,
 		ignoreContext: React.PropTypes.shape( {
 			getDOMNode: React.PropTypes.function
 		} ),
@@ -31,7 +33,8 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'bottom'
+			position: 'bottom',
+			onClick: noop
 		};
 	},
 
@@ -78,6 +81,7 @@ export default React.createClass( {
 	},
 
 	_onClick( event ) {
+		this.props.onClick();
 		event.preventDefault();
 		this.setState( {
 			showPopover: ! this.state.showPopover },

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -226,6 +226,7 @@ const Search = React.createClass( {
 	},
 
 	openSearch: function( event ) {
+		this.props.onClick();
 		event.preventDefault();
 		this.setState( {
 			keyword: '',

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -118,7 +118,17 @@ var analytics = {
 				eventProperties = assign( eventProperties, superProperties );
 			}
 
+			console.log( eventName, eventProperties );
+
 			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+		},
+
+		recordJetpackClick: function( target ) {
+			const props = 'object' === typeof target
+				? target
+				: { target: target };
+
+			analytics.tracks.recordEvent( 'jetpack_wpa_click', props );
 		},
 
 		recordPageView: function( urlPath ) {

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -118,8 +118,6 @@ var analytics = {
 				eventProperties = assign( eventProperties, superProperties );
 			}
 
-			console.log( eventName, eventProperties );
-
 			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 		},
 


### PR DESCRIPTION
This adds a new function for use in tracks, that will help standardize click events from Jetpack wp-admin.  I wrote it so it can take both an object or a string as a property.  

This PR also fixes a couple of components to allow click tracking to be handled on the `onClick` property events for Sarch and Popover components.  