### PR TITLE
Popover: remove tabIndex attribute for div

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -396,7 +396,6 @@ class Popover extends Component {
 					style={ this.getStylePosition() }
 					className={ classes }
 					ref={ this.setDOMBehavior }
-					tabIndex="0"
 				>
 					<div className="dops-popover__arrow" />
 


### PR DESCRIPTION
It was causing a scroll to top on first click.  

Introduced in #106

Fixes: https://github.com/Automattic/jetpack/issues/6824

To Test: 
Link this branch with any branch in Jetpack.  Follow the instructions in the issue linked to reproduce/check the patch.  