### PR TITLE
Add hover to FormToggle on label hover

### DIFF
--- a/client/components/form/form-toggle/style.scss
+++ b/client/components/form/form-toggle/style.scss
@@ -72,7 +72,7 @@
 	}
 
 	&:not( :disabled ) {
-		+ .form-toggle__label .form-toggle__switch:hover {
+		+ .form-toggle__label:hover .form-toggle__switch {
 			background: lighten( $gray, 20% );
 		}
 	}
@@ -88,7 +88,7 @@
 	}
 
 	&:checked:not( :disabled ) {
-		+ .form-toggle__label .form-toggle__switch:hover {
+		+ .form-toggle__label:hover .form-toggle__switch {
 			background: $blue-light;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6878 (package will need to be published and updated).

Related https://github.com/Automattic/wp-calypso/pull/13265 (same PR in Calypso / same fix).

`FormToggle` were only activating the toggle's hover state when the toggle itself was hovered. The entire label is clickable, so it makes sense to show the hover state when any part of the clickable label is hovered. This PR makes hover on the entire clickable area activate the toggle hover state.

![hover-toggle](https://cloud.githubusercontent.com/assets/841763/25229166/90ceb2e2-25cf-11e7-8432-272e1771c415.png)

cc: @jeherve 