### PR TITLE
Update accessibility linter rules to latest version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,9 @@
         "eslint-plugin-react",
         "eslint-plugin-jsx-a11y"
     ],
+    "extends": [
+      "plugin:jsx-a11y/recommended"
+    ],
     "rules": {
         "strict": 0,
         "brace-style": [ 1, "1tbs" ],
@@ -31,36 +34,11 @@
         "eqeqeq": [ 2, "allow-null" ],
         "eol-last": 1,
         "indent": [ 1, "tab", { "SwitchCase": 1 } ],
-        "jsx-a11y/accessible-emoji": 2,
-        // "jsx-a11y/anchor-has-content" doesn"t handle our translation system
-        "jsx-a11y/aria-activedescendant-has-tabindex": 2,
-        "jsx-a11y/aria-props": 2,
-        "jsx-a11y/aria-proptypes": 2,
-        "jsx-a11y/aria-role": 2,
-        "jsx-a11y/aria-unsupported-elements": 2,
-        "jsx-a11y/click-events-have-key-events": 2,
-        "jsx-a11y/heading-has-content": 2,
-        // "jsx-a11y/href-no-hash": 2,
-        "jsx-a11y/html-has-lang": 2,
-        "jsx-a11y/iframe-has-title": 2,
-        // "jsx-a11y/img-has-alt": 2,
-        "jsx-a11y/img-redundant-alt": 2,
-        // "jsx-a11y/label-has-for" Disabled because it doesn"t check nested labels, which are valid
-        "jsx-a11y/lang": 2,
-        "jsx-a11y/mouse-events-have-key-events": 2,
-        "jsx-a11y/no-access-key": 2,
-        // "jsx-a11y/no-autofocus" Replace this with a rule that detects if all autofocus have a describedby
-        "jsx-a11y/no-distracting-elements": 2,
-        "jsx-a11y/no-onchange": 2,
-        "jsx-a11y/no-redundant-roles": 2,
-        // "jsx-a11y/no-static-element-interactions" Not needed right now if the following two rules are set
-        // "jsx-a11y/onclick-has-focus": 2,
-        // "jsx-a11y/onclick-has-role": 2,
-        "jsx-a11y/role-has-required-aria-props": 2,
-        "jsx-a11y/role-supports-aria-props": 2,
-        "jsx-a11y/scope": 2,
-        "jsx-a11y/tabindex-no-positive": 2,
         "key-spacing": 1,
+        "jsx-a11y/anchor-is-valid": [ 2, {
+          "components": [ "Button" ],
+          "aspects": [ "invalidHref" ]
+        } ],
         // Most common is "Emitter", should be improved
         "new-cap": 1,
         "no-cond-assign": 2,

--- a/client/components/form/input-select.jsx
+++ b/client/components/form/input-select.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/no-onchange: 0 */
-
 /** External Dependencies **/
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),

--- a/client/components/hover-icon/index.jsx
+++ b/client/components/hover-icon/index.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/mouse-events-have-key-events: 0 */
-
 var React = require( 'react' ),
 	Icon = require( '../icon' );
 

--- a/client/components/icon.jsx
+++ b/client/components/icon.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/mouse-events-have-key-events: 0 */
-
 // simple genericon wrapper
 
 var React = require( 'react' ),

--- a/client/components/my-sites-navigation/current-site/index.jsx
+++ b/client/components/my-sites-navigation/current-site/index.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/click-events-have-key-events: 0 */
-
 /**
  * External dependencies
  */

--- a/client/components/my-sites-navigation/site-selector/index.jsx
+++ b/client/components/my-sites-navigation/site-selector/index.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/click-events-have-key-events: 0 */
-
 /**
  * External dependencies
  */

--- a/client/components/payment/credit-card-selector.jsx
+++ b/client/components/payment/credit-card-selector.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/click-events-have-key-events: 0 */
-
 require( './credit-card-selector.scss' );
 
 /**

--- a/client/components/slider/index.jsx
+++ b/client/components/slider/index.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/click-events-have-key-events: 0 jsx-a11y/no-onchange: 0 */
-
 /** 
  * Credit for this slider must go to https://github.com/mpowaga/react-slider, 
  * which was the basis for this implementation

--- a/client/components/tabs/index.jsx
+++ b/client/components/tabs/index.jsx
@@ -1,5 +1,3 @@
-/* eslint jsx-a11y/mouse-events-have-key-events: 0 */
-
 var React = require( 'react' );
 
 require( './style.scss' );


### PR DESCRIPTION
A quick PR-on-a-PR for updating the accessibility linting rules. This removes the jsx-a11y rules from being set in our `eslintrc`, and instead relies on the recommended ruleset from the eslint-plugin-jsx-a11y project itself. You can see [the rules they define here](https://github.com/evcohen/eslint-plugin-jsx-a11y#difference-between-recommended-and-strict-mode). (which is what the original set was based on)

I also removed the file-level disabling of rules, since I think we should be fixing those, not ignoring them.

This can be merged into #109 if you want, @gravityrail -- I didn't want to just push to your PR.