### PR TITLE
Removed uppercase styling from button text.

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -60,7 +60,6 @@
 		color: darken( $gray, 10% );
 		font-size: 11px;
 		line-height: 1;
-		text-transform: uppercase;
 
 		&:disabled {
 			color: lighten( $gray, 30% );


### PR DESCRIPTION
Before:

![screenshot from 2017-08-15 22-28-35](https://user-images.githubusercontent.com/374293/29332618-b3a5037c-8211-11e7-9925-a63455430d65.png)

After:

![screenshot from 2017-08-15 22-28-51](https://user-images.githubusercontent.com/374293/29332662-d7958d60-8211-11e7-83ce-d2c5d2d78b61.png)

cc @rickybanister 