### PR TITLE
ClipboardButtonInput: Avoid forwarding unsupported props to the HTML input element

### DIFF
--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -56,10 +56,20 @@ export default React.createClass( {
 	},
 
 	render() {
+		const forwardedProps = omit( this.props,
+			'className',
+			'copied',
+			'copy',
+			'isError',
+			'isValid',
+			'prompt',
+			'selectOnFocus',
+		);
+
 		return (
 			<span className={ classnames( 'dops-clipboard-button-input', this.props.className ) }>
 				<TextInput
-					{ ...omit( this.props, 'className' ) }
+					{ ...forwardedProps }
 					type="text"
 					selectOnFocus
 					readOnly />


### PR DESCRIPTION
Upgrading to React 15, shows that this component is passing down non-standard props to the `<input>` HTML element created by `TextInput`.

#### Testing instructions

1. npm link dops-components in your Jetpack dev env.
1. Build Jetpack
1. Visit the Jetpack Settings Admin Page
1. Confirm that you see no warning related to properties being passed down to `input` from `TextInput`.

