### PR TITLE
Fix critical lodash alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "html-loader": "0.4.5",
     "inherits": "^2.0.1",
     "jquery": "^3.2.1",
-    "lodash": "4.17.4",
+    "lodash": "4.17.21",
     "page": "^1.6.3",
     "payment": "2.2.1",
     "react-addons-transition-group": "^15.6.0",


### PR DESCRIPTION
## Summary
- Bumps lodash from 4.17.4 to 4.17.21 to clear the critical prototype pollution alert.

## Testing
- Parsed package.json and verified lodash 4.17.21 exists in npm.
- git diff --check